### PR TITLE
to_index() should always use gRPC for bulk upserts

### DIFF
--- a/pinecone_datasets/dataset.py
+++ b/pinecone_datasets/dataset.py
@@ -23,7 +23,7 @@ from pinecone_datasets.catalog import DatasetMetadata
 from pinecone_datasets.fs import get_cloud_fs, LocalFileSystem
 
 import pinecone as pc
-from pinecone import Index
+from pinecone import GRPCIndex as Index
 
 
 class DatasetInitializationError(Exception):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ s3fs = "^2023.1.0"
 pydantic = "^1.10.5"
 pandas = "^2.0.0"
 tqdm = "^4.65.0"
-pinecone-client = "^2.2.2"
+pinecone-client = {version = "^2.2.2", extras = ["grpc"]}
 
 
 [tool.poetry.group.dev]


### PR DESCRIPTION
@miararoy my bad, I missed this in #22. That this code should never have been merged - it breaks one of the key principles behind `pinecone-datasets`

## Problem

One of the design principles of `pinecone-dataset` from day one was providing fast bulk upserts via gRPC. which isn't optional. The only change from version 0.5 to 0.6 should have been the underlying client - from still beta Client 3.0 to Client 2.2[grpc].  
`pinecone-datasets` is not meant to support REST based upserts, which can be achieved through the client directly.

## Solution

Made `pinecone-client[grpc]` a mandatory requirement, and use `GRPCIndex` as the only supported index type

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Full coverage in current unit tests