### PR TITLE
support for dataset creation with sentence transformers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ scratchpad.ipynb
 .pytest_cache/
 .coverage
 poetry.lock
+__pycache__

--- a/README.md
+++ b/README.md
@@ -141,6 +141,24 @@ dataset = Dataset.from_pandas(documents = df, quries = None, metadata = metadata
 
 Please check the documentation for more information on the expected dataframe schema. There's also a column mapping variable that can be used to map the dataframe columns to the expected schema.
 
+### Loading from a sentence transformer
+
+Pinecone Datasets enables you to create an embedding dataset using a variety of transformers from [Sentence Transformer](https://huggingface.co/sentence-transformers). Use it to load more than 124 embedding models. 
+
+```python
+sentences = [
+   "How do I get a replacement Medicare card?",
+   "What is the monthly premium for Medicare Part B?"
+]
+
+dataset = Dataset.from_sentence_transformers(
+    'sentence-transformers/all-MiniLM-L6-v2',
+    sentences
+)
+
+```
+
+In the future we may support importing sentences from public Hugging Face datasets.
 
 ## Usage - Accessing data
 
@@ -247,6 +265,7 @@ the `to_index` function also accepts additional parameters
 This project is using poetry for dependency managemet. supported python version are 3.8+. To start developing, on project root directory run:
 
 ```bash
+poetry config virtualenvs.in-project true 
 poetry install --with dev
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ pydantic = "^1.10.5"
 pandas = "^2.0.0"
 tqdm = "^4.65.0"
 pinecone-client = "^2.2.2"
+sentence-transformers = "^2.2.2"
 
 
 [tool.poetry.group.dev]

--- a/tests/unit/test_sentence_transformers.py
+++ b/tests/unit/test_sentence_transformers.py
@@ -1,0 +1,29 @@
+from pinecone_datasets.dataset import Dataset
+
+sentences = [
+   "How do I get a replacement Medicare card?",
+   "What is the monthly premium for Medicare Part B?",
+   "How do I terminate my Medicare Part B (medical insurance)?",
+   "How do I sign up for Medicare?",
+   "Can I sign up for Medicare Part B if I am working and have health insurance through an employer?",
+   "How do I sign up for Medicare Part B if I already have Part A?",
+   "What are Medicare late enrollment penalties?",
+   "What is Medicare and who can get it?",
+   "How can I get help with my Medicare Part A and Part B premiums?",
+   "What are the different parts of Medicare?",
+   "Will my Medicare premiums be higher because of my higher income?",
+   "What is TRICARE ?",
+   "Should I sign up for Medicare Part B if I have Veterans' Benefits?"
+]
+
+def test_sanity():
+   dataset = Dataset.from_sentence_transformers(
+      'sentence-transformers/all-MiniLM-L6-v2',
+      sentences
+   )
+
+   head = dataset.head()
+   
+   print('head')
+   
+   assert(dataset.documents.shape[0]==len(sentences))


### PR DESCRIPTION
## Problem

@miararoy @igiloh-pinecone

It would be nice to do something like:

```python
sentences = [
   "How do I get a replacement Medicare card?",
   "What is the monthly premium for Medicare Part B?"
]

dataset = Dataset.from_sentence_transformers(
    'sentence-transformers/all-MiniLM-L6-v2',
    sentences
)

```

There are more than 124 embedding models, that work with the [Sentence Transformers](https://huggingface.co/sentence-transformers) library

## Solution

Creating a simple static interface inside the `Dataset` class and connect it with the sentence transformers api.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [-] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

I have added a preliminary test that passes. I would love to add more coverage tests for this 