### PR TITLE
[Bug] Infinite loop when listing the contents of an empty catalog

### DIFF
--- a/pinecone_datasets/__init__.py
+++ b/pinecone_datasets/__init__.py
@@ -2,7 +2,7 @@
 .. include:: ../README.md
 """
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 
 from .public import list_datasets, load_dataset

--- a/pinecone_datasets/catalog.py
+++ b/pinecone_datasets/catalog.py
@@ -61,7 +61,6 @@ class Catalog(BaseModel):
 
         self.datasets = collected_datasets
         logger.info(f"Loaded {len(self.datasets)} datasets from {self.base_path}")
-        logger.debug(f"Datasets in {self.base_path}: {self.list_datasets(as_df=False)}")
         return self
 
     def list_datasets(self, as_df: bool) -> Union[List[str], "pd.DataFrame"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pinecone-datasets"
-version = "1.0.0"
+version = "1.0.1"
 description = "Load datasets to explore Pinecone"
 authors = ["Pinecone Support <support@pinecone.io>"]
 maintainers = [

--- a/tests/integration/test_io_local.py
+++ b/tests/integration/test_io_local.py
@@ -47,6 +47,10 @@ q = pd.DataFrame(
 
 
 class TestLocalIO:
+    def test_empty_catalog(self, tmpdir):
+        catalog = Catalog(base_path=str(tmpdir.mkdir("catalog")))
+        assert catalog.list_datasets(as_df=False) == []
+
     def test_io_write_to_local(self, tmpdir):
         dataset_name = "test_io_dataset"
         metadata = DatasetMetadata(

--- a/tests/unit/test_basics.py
+++ b/tests/unit/test_basics.py
@@ -14,4 +14,4 @@ else:
 
 
 def test_version():
-    assert __version__ == "1.0.0"
+    assert __version__ == "1.0.1"


### PR DESCRIPTION
## Problem

When trying to call `Catalog.list_datasets` on an empty catalog, you go into an infinite loop.

```python
from pinecone_datasets import Catalog

catalog = Catalog(base_path='/path/to/empty/dir')
catalog.list_datasets() # infinite loop
```

## Solution

Add test and remove the offending log line attempting to call list_datasets as they are being loaded in.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

