### PR TITLE
Error path test coverage

### DIFF
--- a/tests/integration/test_error_scenarios.py
+++ b/tests/integration/test_error_scenarios.py
@@ -1,0 +1,567 @@
+import pytest
+import json
+import os
+import pandas as pd
+import tempfile
+import shutil
+from unittest.mock import Mock, patch
+import concurrent.futures
+import threading
+
+from pinecone_datasets import Dataset, Catalog, DatasetMetadata, DenseModelMetadata
+from pinecone_datasets.dataset_fsreader import DatasetFSReader
+from pinecone_datasets.dataset_fswriter import DatasetFSWriter
+
+
+class TestIntegrationErrorScenarios:
+    """Integration tests for complex error scenarios"""
+
+    def test_concurrent_read_operations(self, tmpdir):
+        """Test concurrent read operations on same dataset"""
+        # Create a valid dataset
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        documents_path = os.path.join(dataset_path, "documents")
+        os.makedirs(documents_path)
+        
+        documents_data = pd.DataFrame([
+            {
+                "id": str(i),
+                "values": [float(i), float(i+1)],
+                "metadata": {"index": i}
+            }
+            for i in range(100)
+        ])
+        documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
+        
+        metadata = {
+            "name": "test",
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": 100,
+            "queries": 0,
+            "dense_model": {"name": "ada2", "dimension": 2}
+        }
+        with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
+            json.dump(metadata, f)
+        
+        # Perform concurrent reads
+        def read_dataset():
+            ds = Dataset.from_path(dataset_path)
+            return len(ds.documents)
+        
+        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [executor.submit(read_dataset) for _ in range(10)]
+            results = [f.result() for f in concurrent.futures.as_completed(futures)]
+        
+        # All reads should succeed
+        assert all(r == 100 for r in results)
+
+    def test_concurrent_write_operations(self, tmpdir):
+        """Test concurrent write operations to different datasets"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        catalog = Catalog(base_path=catalog_path)
+        
+        def write_dataset(index):
+            documents = pd.DataFrame([
+                {
+                    "id": f"{index}-{i}",
+                    "values": [float(i), float(i+1)],
+                    "metadata": {"index": i}
+                }
+                for i in range(10)
+            ])
+            
+            metadata = DatasetMetadata(
+                name=f"dataset_{index}",
+                created_at="2021-01-01 00:00:00.000000",
+                documents=10,
+                queries=0,
+                dense_model=DenseModelMetadata(name="ada2", dimension=2)
+            )
+            
+            dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+            catalog.save_dataset(dataset)
+            return index
+        
+        # Write multiple datasets concurrently
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+            futures = [executor.submit(write_dataset, i) for i in range(5)]
+            results = [f.result() for f in concurrent.futures.as_completed(futures)]
+        
+        # All writes should succeed
+        assert len(results) == 5
+        assert set(results) == {0, 1, 2, 3, 4}
+        
+        # Verify all datasets were created
+        for i in range(5):
+            dataset_path = os.path.join(catalog_path, f"dataset_{i}")
+            assert os.path.exists(dataset_path)
+
+    def test_concurrent_read_write_same_location(self, tmpdir):
+        """Test concurrent read and write to same location causes appropriate errors"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        documents_path = os.path.join(dataset_path, "documents")
+        os.makedirs(documents_path)
+        
+        # Create initial dataset
+        documents_data = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
+        
+        metadata = {
+            "name": "test",
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": 1,
+            "queries": 0,
+            "dense_model": {"name": "ada2", "dimension": 2}
+        }
+        with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
+            json.dump(metadata, f)
+        
+        errors = []
+        
+        def read_dataset():
+            try:
+                ds = Dataset.from_path(dataset_path)
+                return len(ds.documents)
+            except Exception as e:
+                errors.append(e)
+                return None
+        
+        def write_dataset():
+            try:
+                documents = pd.DataFrame([
+                    {
+                        "id": "2",
+                        "values": [0.3, 0.4],
+                        "metadata": {"key": "value2"}
+                    }
+                ])
+                
+                meta = DatasetMetadata(
+                    name="test",
+                    created_at="2021-01-01 00:00:00.000000",
+                    documents=1,
+                    queries=0,
+                    dense_model=DenseModelMetadata(name="ada2", dimension=2)
+                )
+                
+                ds = Dataset.from_pandas(documents=documents, queries=None, metadata=meta)
+                DatasetFSWriter.write_dataset(dataset_path, ds)
+                return True
+            except Exception as e:
+                errors.append(e)
+                return False
+        
+        # Perform concurrent reads and writes
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+            futures = []
+            futures.extend([executor.submit(read_dataset) for _ in range(2)])
+            futures.extend([executor.submit(write_dataset) for _ in range(2)])
+            results = [f.result() for f in concurrent.futures.as_completed(futures)]
+        
+        # Some operations should succeed, and we shouldn't have crashes
+        assert len(results) == 4
+
+    def test_large_dataset_memory_handling(self, tmpdir):
+        """Test handling of large dataset"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        documents_path = os.path.join(dataset_path, "documents")
+        os.makedirs(documents_path)
+        
+        # Create a moderately large dataset
+        num_rows = 10000
+        documents_data = pd.DataFrame([
+            {
+                "id": str(i),
+                "values": [float(i) for _ in range(100)],  # 100-dimensional vectors
+                "metadata": {"index": i, "description": f"document_{i}" * 10}
+            }
+            for i in range(num_rows)
+        ])
+        
+        documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
+        
+        metadata = {
+            "name": "large_dataset",
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": num_rows,
+            "queries": 0,
+            "dense_model": {"name": "ada2", "dimension": 100}
+        }
+        with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
+            json.dump(metadata, f)
+        
+        # Load and verify
+        ds = Dataset.from_path(dataset_path)
+        assert len(ds.documents) == num_rows
+        
+        # Test iteration (more memory efficient than loading all at once)
+        count = 0
+        for batch in ds.iter_documents(batch_size=100):
+            count += len(batch)
+        assert count == num_rows
+
+    def test_multiple_parquet_files_with_errors(self, tmpdir):
+        """Test loading dataset with multiple parquet files, some with errors"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        documents_path = os.path.join(dataset_path, "documents")
+        os.makedirs(documents_path)
+        
+        # Create valid parquet files
+        for i in range(3):
+            data = pd.DataFrame([
+                {
+                    "id": f"{i}-{j}",
+                    "values": [float(j), float(j+1)],
+                    "metadata": {"index": j}
+                }
+                for j in range(10)
+            ])
+            data.to_parquet(os.path.join(documents_path, f"part-{i}.parquet"))
+        
+        # Add a corrupted parquet file
+        with open(os.path.join(documents_path, "part-3.parquet"), "w") as f:
+            f.write("corrupted data")
+        
+        metadata = {
+            "name": "test",
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": 30,
+            "queries": 0,
+            "dense_model": {"name": "ada2", "dimension": 2}
+        }
+        with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
+            json.dump(metadata, f)
+        
+        # Should fail when encountering corrupted file
+        from fsspec.implementations.local import LocalFileSystem
+        fs = LocalFileSystem()
+        
+        with pytest.raises(Exception):
+            DatasetFSReader.read_documents(fs, dataset_path)
+
+    def test_partial_dataset_write(self, tmpdir):
+        """Test recovery from partial dataset write"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        catalog = Catalog(base_path=catalog_path)
+        
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="partial_dataset",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        
+        # Mock to simulate failure during metadata write
+        original_write_metadata = DatasetFSWriter._write_metadata
+        
+        def failing_write_metadata(fs, dataset_path, dataset):
+            # Documents already written, now fail on metadata
+            raise IOError("Simulated failure during metadata write")
+        
+        with patch.object(DatasetFSWriter, '_write_metadata', side_effect=failing_write_metadata):
+            with pytest.raises(IOError):
+                catalog.save_dataset(dataset)
+        
+        # Dataset directory should exist but be incomplete
+        dataset_path = os.path.join(catalog_path, "partial_dataset")
+        if os.path.exists(dataset_path):
+            # If documents directory exists, metadata.json should not
+            documents_dir = os.path.join(dataset_path, "documents")
+            metadata_file = os.path.join(dataset_path, "metadata.json")
+            if os.path.exists(documents_dir):
+                assert not os.path.exists(metadata_file)
+
+    def test_empty_dataset_handling(self, tmpdir):
+        """Test handling of completely empty dataset"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        
+        # Create directories but no data
+        os.makedirs(os.path.join(dataset_path, "documents"))
+        
+        metadata = {
+            "name": "empty_dataset",
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": 0,
+            "queries": 0,
+            "dense_model": {"name": "ada2", "dimension": 2}
+        }
+        with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
+            json.dump(metadata, f)
+        
+        from fsspec.implementations.local import LocalFileSystem
+        fs = LocalFileSystem()
+        
+        # Should raise ValueError when no parquet files found in existing directory
+        with pytest.raises(ValueError, match="No parquet files found"):
+            DatasetFSReader.read_documents(fs, dataset_path)
+
+    def test_dataset_with_missing_optional_fields(self, tmpdir):
+        """Test dataset where all optional fields are missing"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        documents_path = os.path.join(dataset_path, "documents")
+        os.makedirs(documents_path)
+        
+        # Documents with only required fields
+        documents_data = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2]
+            }
+        ])
+        documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
+        
+        metadata = {
+            "name": "minimal_dataset",
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": 1,
+            "queries": 0,
+            "dense_model": {"name": "ada2", "dimension": 2}
+        }
+        with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
+            json.dump(metadata, f)
+        
+        # Should load successfully and add None for optional fields
+        ds = Dataset.from_path(dataset_path)
+        assert len(ds.documents) == 1
+        assert "metadata" in ds.documents.columns
+        assert "sparse_values" in ds.documents.columns
+
+    def test_catalog_with_many_datasets(self, tmpdir):
+        """Test catalog operations with many datasets"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        catalog = Catalog(base_path=catalog_path)
+        
+        # Create 50 datasets
+        num_datasets = 50
+        for i in range(num_datasets):
+            documents = pd.DataFrame([
+                {
+                    "id": "1",
+                    "values": [float(i), float(i+1)],
+                    "metadata": {"index": i}
+                }
+            ])
+            
+            metadata = DatasetMetadata(
+                name=f"dataset_{i:03d}",
+                created_at="2021-01-01 00:00:00.000000",
+                documents=1,
+                queries=0,
+                dense_model=DenseModelMetadata(name="ada2", dimension=2)
+            )
+            
+            dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+            catalog.save_dataset(dataset)
+        
+        # Load catalog
+        catalog = Catalog(base_path=catalog_path)
+        catalog.load()
+        
+        assert len(catalog.datasets) == num_datasets
+        
+        # List datasets
+        dataset_names = catalog.list_datasets(as_df=False)
+        assert len(dataset_names) == num_datasets
+
+    def test_network_retry_scenario(self, tmpdir):
+        """Test simulated network retry scenario"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        documents_path = os.path.join(dataset_path, "documents")
+        os.makedirs(documents_path)
+        
+        documents_data = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
+        
+        metadata = {
+            "name": "test",
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": 1,
+            "queries": 0,
+            "dense_model": {"name": "ada2", "dimension": 2}
+        }
+        with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
+            json.dump(metadata, f)
+        
+        # Simulate intermittent network failures
+        call_count = [0]
+        
+        def flaky_open(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] < 3:
+                raise IOError("Network error")
+            # Use real implementation
+            from fsspec.implementations.local import LocalFileSystem
+            return LocalFileSystem().open(*args, **kwargs)
+        
+        from fsspec.implementations.local import LocalFileSystem
+        fs = LocalFileSystem()
+        
+        # Mock open to be flaky
+        with patch.object(fs, 'open', side_effect=flaky_open):
+            # First attempt should fail
+            with pytest.raises(IOError):
+                DatasetFSReader.read_metadata(fs, dataset_path)
+            
+            # Second attempt should also fail
+            with pytest.raises(IOError):
+                DatasetFSReader.read_metadata(fs, dataset_path)
+
+    def test_dataset_schema_evolution(self, tmpdir):
+        """Test handling datasets with schema changes"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        documents_path = os.path.join(dataset_path, "documents")
+        os.makedirs(documents_path)
+        
+        # Create parquet with extra column
+        documents_data = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"},
+                "extra_column": "extra_data"  # Not in schema
+            }
+        ])
+        documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
+        
+        metadata = {
+            "name": "test",
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": 1,
+            "queries": 0,
+            "dense_model": {"name": "ada2", "dimension": 2}
+        }
+        with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
+            json.dump(metadata, f)
+        
+        # Should load successfully, extra column is allowed
+        ds = Dataset.from_path(dataset_path)
+        assert len(ds.documents) == 1
+
+    def test_inconsistent_parquet_schemas(self, tmpdir):
+        """Test loading dataset with inconsistent schemas across parquet files"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        documents_path = os.path.join(dataset_path, "documents")
+        os.makedirs(documents_path)
+        
+        # First parquet with standard schema
+        data1 = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        data1.to_parquet(os.path.join(documents_path, "part-0.parquet"))
+        
+        # Second parquet with extra column
+        data2 = pd.DataFrame([
+            {
+                "id": "2",
+                "values": [0.3, 0.4],
+                "metadata": {"key": "value2"},
+                "extra_field": "extra"
+            }
+        ])
+        data2.to_parquet(os.path.join(documents_path, "part-1.parquet"))
+        
+        metadata = {
+            "name": "test",
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": 2,
+            "queries": 0,
+            "dense_model": {"name": "ada2", "dimension": 2}
+        }
+        with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
+            json.dump(metadata, f)
+        
+        # Should handle schema differences gracefully
+        ds = Dataset.from_path(dataset_path)
+        assert len(ds.documents) == 2
+
+    def test_resource_cleanup_on_error(self, tmpdir):
+        """Test that resources are properly cleaned up on error"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        
+        # Mock to cause error during write
+        from fsspec.implementations.local import LocalFileSystem
+        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=LocalFileSystem()):
+            with patch('builtins.open', side_effect=IOError("Simulated error")):
+                with pytest.raises(IOError):
+                    DatasetFSWriter.write_dataset(dataset_path, dataset)
+        
+        # Original dataset should still be intact
+        assert dataset.documents is not None
+        assert len(dataset.documents) == 1
+
+    def test_unicode_in_metadata(self, tmpdir):
+        """Test handling unicode characters in metadata"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        documents_path = os.path.join(dataset_path, "documents")
+        os.makedirs(documents_path)
+        
+        # Documents with unicode in metadata
+        documents_data = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"text": "日本語", "emoji": "🎉", "chinese": "中文"}
+            }
+        ])
+        documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
+        
+        metadata = {
+            "name": "unicode_dataset",
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": 1,
+            "queries": 0,
+            "dense_model": {"name": "ada2", "dimension": 2},
+            "description": "データセット with unicode 🌟"
+        }
+        with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
+            json.dump(metadata, f, ensure_ascii=False)
+        
+        # Should load successfully
+        ds = Dataset.from_path(dataset_path)
+        assert len(ds.documents) == 1
+        assert ds.metadata.description == "データセット with unicode 🌟"

--- a/tests/integration/test_error_scenarios.py
+++ b/tests/integration/test_error_scenarios.py
@@ -1,14 +1,12 @@
-import pytest
+import concurrent.futures
 import json
 import os
-import pandas as pd
-import tempfile
-import shutil
-from unittest.mock import Mock, patch
-import concurrent.futures
-import threading
 
-from pinecone_datasets import Dataset, Catalog, DatasetMetadata, DenseModelMetadata
+import pandas as pd
+import pytest
+from unittest.mock import patch
+
+from pinecone_datasets import Catalog, Dataset, DatasetMetadata, DenseModelMetadata
 from pinecone_datasets.dataset_fsreader import DatasetFSReader
 from pinecone_datasets.dataset_fswriter import DatasetFSWriter
 
@@ -274,7 +272,7 @@ class TestIntegrationErrorScenarios:
         # Mock to simulate failure during metadata write
         def failing_write_metadata(fs, dataset_path, dataset):
             # Documents already written, now fail on metadata
-            raise IOError("Simulated failure during metadata write")
+            raise OSError("Simulated failure during metadata write")
 
         with patch.object(
             DatasetFSWriter, "_write_metadata", side_effect=failing_write_metadata

--- a/tests/integration/test_error_scenarios.py
+++ b/tests/integration/test_error_scenarios.py
@@ -272,8 +272,6 @@ class TestIntegrationErrorScenarios:
         )
 
         # Mock to simulate failure during metadata write
-        original_write_metadata = DatasetFSWriter._write_metadata
-
         def failing_write_metadata(fs, dataset_path, dataset):
             # Documents already written, now fail on metadata
             raise IOError("Simulated failure during metadata write")

--- a/tests/integration/test_error_scenarios.py
+++ b/tests/integration/test_error_scenarios.py
@@ -22,36 +22,38 @@ class TestIntegrationErrorScenarios:
         dataset_path = str(tmpdir.mkdir("dataset"))
         documents_path = os.path.join(dataset_path, "documents")
         os.makedirs(documents_path)
-        
-        documents_data = pd.DataFrame([
-            {
-                "id": str(i),
-                "values": [float(i), float(i+1)],
-                "metadata": {"index": i}
-            }
-            for i in range(100)
-        ])
+
+        documents_data = pd.DataFrame(
+            [
+                {
+                    "id": str(i),
+                    "values": [float(i), float(i + 1)],
+                    "metadata": {"index": i},
+                }
+                for i in range(100)
+            ]
+        )
         documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
-        
+
         metadata = {
             "name": "test",
             "created_at": "2021-01-01 00:00:00.000000",
             "documents": 100,
             "queries": 0,
-            "dense_model": {"name": "ada2", "dimension": 2}
+            "dense_model": {"name": "ada2", "dimension": 2},
         }
         with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
             json.dump(metadata, f)
-        
+
         # Perform concurrent reads
         def read_dataset():
             ds = Dataset.from_path(dataset_path)
             return len(ds.documents)
-        
+
         with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
             futures = [executor.submit(read_dataset) for _ in range(10)]
             results = [f.result() for f in concurrent.futures.as_completed(futures)]
-        
+
         # All reads should succeed
         assert all(r == 100 for r in results)
 
@@ -59,38 +61,42 @@ class TestIntegrationErrorScenarios:
         """Test concurrent write operations to different datasets"""
         catalog_path = str(tmpdir.mkdir("catalog"))
         catalog = Catalog(base_path=catalog_path)
-        
+
         def write_dataset(index):
-            documents = pd.DataFrame([
-                {
-                    "id": f"{index}-{i}",
-                    "values": [float(i), float(i+1)],
-                    "metadata": {"index": i}
-                }
-                for i in range(10)
-            ])
-            
+            documents = pd.DataFrame(
+                [
+                    {
+                        "id": f"{index}-{i}",
+                        "values": [float(i), float(i + 1)],
+                        "metadata": {"index": i},
+                    }
+                    for i in range(10)
+                ]
+            )
+
             metadata = DatasetMetadata(
                 name=f"dataset_{index}",
                 created_at="2021-01-01 00:00:00.000000",
                 documents=10,
                 queries=0,
-                dense_model=DenseModelMetadata(name="ada2", dimension=2)
+                dense_model=DenseModelMetadata(name="ada2", dimension=2),
             )
-            
-            dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+
+            dataset = Dataset.from_pandas(
+                documents=documents, queries=None, metadata=metadata
+            )
             catalog.save_dataset(dataset)
             return index
-        
+
         # Write multiple datasets concurrently
         with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
             futures = [executor.submit(write_dataset, i) for i in range(5)]
             results = [f.result() for f in concurrent.futures.as_completed(futures)]
-        
+
         # All writes should succeed
         assert len(results) == 5
         assert set(results) == {0, 1, 2, 3, 4}
-        
+
         # Verify all datasets were created
         for i in range(5):
             dataset_path = os.path.join(catalog_path, f"dataset_{i}")
@@ -101,29 +107,25 @@ class TestIntegrationErrorScenarios:
         dataset_path = str(tmpdir.mkdir("dataset"))
         documents_path = os.path.join(dataset_path, "documents")
         os.makedirs(documents_path)
-        
+
         # Create initial dataset
-        documents_data = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"key": "value"}
-            }
-        ])
+        documents_data = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": {"key": "value"}}]
+        )
         documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
-        
+
         metadata = {
             "name": "test",
             "created_at": "2021-01-01 00:00:00.000000",
             "documents": 1,
             "queries": 0,
-            "dense_model": {"name": "ada2", "dimension": 2}
+            "dense_model": {"name": "ada2", "dimension": 2},
         }
         with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
             json.dump(metadata, f)
-        
+
         errors = []
-        
+
         def read_dataset():
             try:
                 ds = Dataset.from_path(dataset_path)
@@ -131,39 +133,37 @@ class TestIntegrationErrorScenarios:
             except Exception as e:
                 errors.append(e)
                 return None
-        
+
         def write_dataset():
             try:
-                documents = pd.DataFrame([
-                    {
-                        "id": "2",
-                        "values": [0.3, 0.4],
-                        "metadata": {"key": "value2"}
-                    }
-                ])
-                
+                documents = pd.DataFrame(
+                    [{"id": "2", "values": [0.3, 0.4], "metadata": {"key": "value2"}}]
+                )
+
                 meta = DatasetMetadata(
                     name="test",
                     created_at="2021-01-01 00:00:00.000000",
                     documents=1,
                     queries=0,
-                    dense_model=DenseModelMetadata(name="ada2", dimension=2)
+                    dense_model=DenseModelMetadata(name="ada2", dimension=2),
                 )
-                
-                ds = Dataset.from_pandas(documents=documents, queries=None, metadata=meta)
+
+                ds = Dataset.from_pandas(
+                    documents=documents, queries=None, metadata=meta
+                )
                 DatasetFSWriter.write_dataset(dataset_path, ds)
                 return True
             except Exception as e:
                 errors.append(e)
                 return False
-        
+
         # Perform concurrent reads and writes
         with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
             futures = []
             futures.extend([executor.submit(read_dataset) for _ in range(2)])
             futures.extend([executor.submit(write_dataset) for _ in range(2)])
             results = [f.result() for f in concurrent.futures.as_completed(futures)]
-        
+
         # Some operations should succeed, and we shouldn't have crashes
         assert len(results) == 4
 
@@ -172,34 +172,36 @@ class TestIntegrationErrorScenarios:
         dataset_path = str(tmpdir.mkdir("dataset"))
         documents_path = os.path.join(dataset_path, "documents")
         os.makedirs(documents_path)
-        
+
         # Create a moderately large dataset
         num_rows = 10000
-        documents_data = pd.DataFrame([
-            {
-                "id": str(i),
-                "values": [float(i) for _ in range(100)],  # 100-dimensional vectors
-                "metadata": {"index": i, "description": f"document_{i}" * 10}
-            }
-            for i in range(num_rows)
-        ])
-        
+        documents_data = pd.DataFrame(
+            [
+                {
+                    "id": str(i),
+                    "values": [float(i) for _ in range(100)],  # 100-dimensional vectors
+                    "metadata": {"index": i, "description": f"document_{i}" * 10},
+                }
+                for i in range(num_rows)
+            ]
+        )
+
         documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
-        
+
         metadata = {
             "name": "large_dataset",
             "created_at": "2021-01-01 00:00:00.000000",
             "documents": num_rows,
             "queries": 0,
-            "dense_model": {"name": "ada2", "dimension": 100}
+            "dense_model": {"name": "ada2", "dimension": 100},
         }
         with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
             json.dump(metadata, f)
-        
+
         # Load and verify
         ds = Dataset.from_path(dataset_path)
         assert len(ds.documents) == num_rows
-        
+
         # Test iteration (more memory efficient than loading all at once)
         count = 0
         for batch in ds.iter_documents(batch_size=100):
@@ -211,37 +213,40 @@ class TestIntegrationErrorScenarios:
         dataset_path = str(tmpdir.mkdir("dataset"))
         documents_path = os.path.join(dataset_path, "documents")
         os.makedirs(documents_path)
-        
+
         # Create valid parquet files
         for i in range(3):
-            data = pd.DataFrame([
-                {
-                    "id": f"{i}-{j}",
-                    "values": [float(j), float(j+1)],
-                    "metadata": {"index": j}
-                }
-                for j in range(10)
-            ])
+            data = pd.DataFrame(
+                [
+                    {
+                        "id": f"{i}-{j}",
+                        "values": [float(j), float(j + 1)],
+                        "metadata": {"index": j},
+                    }
+                    for j in range(10)
+                ]
+            )
             data.to_parquet(os.path.join(documents_path, f"part-{i}.parquet"))
-        
+
         # Add a corrupted parquet file
         with open(os.path.join(documents_path, "part-3.parquet"), "w") as f:
             f.write("corrupted data")
-        
+
         metadata = {
             "name": "test",
             "created_at": "2021-01-01 00:00:00.000000",
             "documents": 30,
             "queries": 0,
-            "dense_model": {"name": "ada2", "dimension": 2}
+            "dense_model": {"name": "ada2", "dimension": 2},
         }
         with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
             json.dump(metadata, f)
-        
+
         # Should fail when encountering corrupted file
         from fsspec.implementations.local import LocalFileSystem
+
         fs = LocalFileSystem()
-        
+
         with pytest.raises(Exception):
             DatasetFSReader.read_documents(fs, dataset_path)
 
@@ -249,36 +254,36 @@ class TestIntegrationErrorScenarios:
         """Test recovery from partial dataset write"""
         catalog_path = str(tmpdir.mkdir("catalog"))
         catalog = Catalog(base_path=catalog_path)
-        
-        documents = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"key": "value"}
-            }
-        ])
-        
+
+        documents = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": {"key": "value"}}]
+        )
+
         metadata = DatasetMetadata(
             name="partial_dataset",
             created_at="2021-01-01 00:00:00.000000",
             documents=1,
             queries=0,
-            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+            dense_model=DenseModelMetadata(name="ada2", dimension=2),
         )
-        
-        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
-        
+
+        dataset = Dataset.from_pandas(
+            documents=documents, queries=None, metadata=metadata
+        )
+
         # Mock to simulate failure during metadata write
         original_write_metadata = DatasetFSWriter._write_metadata
-        
+
         def failing_write_metadata(fs, dataset_path, dataset):
             # Documents already written, now fail on metadata
             raise IOError("Simulated failure during metadata write")
-        
-        with patch.object(DatasetFSWriter, '_write_metadata', side_effect=failing_write_metadata):
+
+        with patch.object(
+            DatasetFSWriter, "_write_metadata", side_effect=failing_write_metadata
+        ):
             with pytest.raises(IOError):
                 catalog.save_dataset(dataset)
-        
+
         # Dataset directory should exist but be incomplete
         dataset_path = os.path.join(catalog_path, "partial_dataset")
         if os.path.exists(dataset_path):
@@ -291,23 +296,24 @@ class TestIntegrationErrorScenarios:
     def test_empty_dataset_handling(self, tmpdir):
         """Test handling of completely empty dataset"""
         dataset_path = str(tmpdir.mkdir("dataset"))
-        
+
         # Create directories but no data
         os.makedirs(os.path.join(dataset_path, "documents"))
-        
+
         metadata = {
             "name": "empty_dataset",
             "created_at": "2021-01-01 00:00:00.000000",
             "documents": 0,
             "queries": 0,
-            "dense_model": {"name": "ada2", "dimension": 2}
+            "dense_model": {"name": "ada2", "dimension": 2},
         }
         with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
             json.dump(metadata, f)
-        
+
         from fsspec.implementations.local import LocalFileSystem
+
         fs = LocalFileSystem()
-        
+
         # Should raise ValueError when no parquet files found in existing directory
         with pytest.raises(ValueError, match="No parquet files found"):
             DatasetFSReader.read_documents(fs, dataset_path)
@@ -317,26 +323,21 @@ class TestIntegrationErrorScenarios:
         dataset_path = str(tmpdir.mkdir("dataset"))
         documents_path = os.path.join(dataset_path, "documents")
         os.makedirs(documents_path)
-        
+
         # Documents with only required fields
-        documents_data = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2]
-            }
-        ])
+        documents_data = pd.DataFrame([{"id": "1", "values": [0.1, 0.2]}])
         documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
-        
+
         metadata = {
             "name": "minimal_dataset",
             "created_at": "2021-01-01 00:00:00.000000",
             "documents": 1,
             "queries": 0,
-            "dense_model": {"name": "ada2", "dimension": 2}
+            "dense_model": {"name": "ada2", "dimension": 2},
         }
         with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
             json.dump(metadata, f)
-        
+
         # Should load successfully and add None for optional fields
         ds = Dataset.from_path(dataset_path)
         assert len(ds.documents) == 1
@@ -347,35 +348,39 @@ class TestIntegrationErrorScenarios:
         """Test catalog operations with many datasets"""
         catalog_path = str(tmpdir.mkdir("catalog"))
         catalog = Catalog(base_path=catalog_path)
-        
+
         # Create 50 datasets
         num_datasets = 50
         for i in range(num_datasets):
-            documents = pd.DataFrame([
-                {
-                    "id": "1",
-                    "values": [float(i), float(i+1)],
-                    "metadata": {"index": i}
-                }
-            ])
-            
+            documents = pd.DataFrame(
+                [
+                    {
+                        "id": "1",
+                        "values": [float(i), float(i + 1)],
+                        "metadata": {"index": i},
+                    }
+                ]
+            )
+
             metadata = DatasetMetadata(
                 name=f"dataset_{i:03d}",
                 created_at="2021-01-01 00:00:00.000000",
                 documents=1,
                 queries=0,
-                dense_model=DenseModelMetadata(name="ada2", dimension=2)
+                dense_model=DenseModelMetadata(name="ada2", dimension=2),
             )
-            
-            dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+
+            dataset = Dataset.from_pandas(
+                documents=documents, queries=None, metadata=metadata
+            )
             catalog.save_dataset(dataset)
-        
+
         # Load catalog
         catalog = Catalog(base_path=catalog_path)
         catalog.load()
-        
+
         assert len(catalog.datasets) == num_datasets
-        
+
         # List datasets
         dataset_names = catalog.list_datasets(as_df=False)
         assert len(dataset_names) == num_datasets
@@ -385,46 +390,44 @@ class TestIntegrationErrorScenarios:
         dataset_path = str(tmpdir.mkdir("dataset"))
         documents_path = os.path.join(dataset_path, "documents")
         os.makedirs(documents_path)
-        
-        documents_data = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"key": "value"}
-            }
-        ])
+
+        documents_data = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": {"key": "value"}}]
+        )
         documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
-        
+
         metadata = {
             "name": "test",
             "created_at": "2021-01-01 00:00:00.000000",
             "documents": 1,
             "queries": 0,
-            "dense_model": {"name": "ada2", "dimension": 2}
+            "dense_model": {"name": "ada2", "dimension": 2},
         }
         with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
             json.dump(metadata, f)
-        
+
         # Simulate intermittent network failures
         call_count = [0]
-        
+
         def flaky_open(*args, **kwargs):
             call_count[0] += 1
             if call_count[0] < 3:
                 raise IOError("Network error")
             # Use real implementation
             from fsspec.implementations.local import LocalFileSystem
+
             return LocalFileSystem().open(*args, **kwargs)
-        
+
         from fsspec.implementations.local import LocalFileSystem
+
         fs = LocalFileSystem()
-        
+
         # Mock open to be flaky
-        with patch.object(fs, 'open', side_effect=flaky_open):
+        with patch.object(fs, "open", side_effect=flaky_open):
             # First attempt should fail
             with pytest.raises(IOError):
                 DatasetFSReader.read_metadata(fs, dataset_path)
-            
+
             # Second attempt should also fail
             with pytest.raises(IOError):
                 DatasetFSReader.read_metadata(fs, dataset_path)
@@ -434,28 +437,30 @@ class TestIntegrationErrorScenarios:
         dataset_path = str(tmpdir.mkdir("dataset"))
         documents_path = os.path.join(dataset_path, "documents")
         os.makedirs(documents_path)
-        
+
         # Create parquet with extra column
-        documents_data = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"key": "value"},
-                "extra_column": "extra_data"  # Not in schema
-            }
-        ])
+        documents_data = pd.DataFrame(
+            [
+                {
+                    "id": "1",
+                    "values": [0.1, 0.2],
+                    "metadata": {"key": "value"},
+                    "extra_column": "extra_data",  # Not in schema
+                }
+            ]
+        )
         documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
-        
+
         metadata = {
             "name": "test",
             "created_at": "2021-01-01 00:00:00.000000",
             "documents": 1,
             "queries": 0,
-            "dense_model": {"name": "ada2", "dimension": 2}
+            "dense_model": {"name": "ada2", "dimension": 2},
         }
         with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
             json.dump(metadata, f)
-        
+
         # Should load successfully, extra column is allowed
         ds = Dataset.from_path(dataset_path)
         assert len(ds.documents) == 1
@@ -465,38 +470,36 @@ class TestIntegrationErrorScenarios:
         dataset_path = str(tmpdir.mkdir("dataset"))
         documents_path = os.path.join(dataset_path, "documents")
         os.makedirs(documents_path)
-        
+
         # First parquet with standard schema
-        data1 = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"key": "value"}
-            }
-        ])
+        data1 = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": {"key": "value"}}]
+        )
         data1.to_parquet(os.path.join(documents_path, "part-0.parquet"))
-        
+
         # Second parquet with extra column
-        data2 = pd.DataFrame([
-            {
-                "id": "2",
-                "values": [0.3, 0.4],
-                "metadata": {"key": "value2"},
-                "extra_field": "extra"
-            }
-        ])
+        data2 = pd.DataFrame(
+            [
+                {
+                    "id": "2",
+                    "values": [0.3, 0.4],
+                    "metadata": {"key": "value2"},
+                    "extra_field": "extra",
+                }
+            ]
+        )
         data2.to_parquet(os.path.join(documents_path, "part-1.parquet"))
-        
+
         metadata = {
             "name": "test",
             "created_at": "2021-01-01 00:00:00.000000",
             "documents": 2,
             "queries": 0,
-            "dense_model": {"name": "ada2", "dimension": 2}
+            "dense_model": {"name": "ada2", "dimension": 2},
         }
         with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
             json.dump(metadata, f)
-        
+
         # Should handle schema differences gracefully
         ds = Dataset.from_path(dataset_path)
         assert len(ds.documents) == 2
@@ -504,32 +507,34 @@ class TestIntegrationErrorScenarios:
     def test_resource_cleanup_on_error(self, tmpdir):
         """Test that resources are properly cleaned up on error"""
         dataset_path = str(tmpdir.mkdir("dataset"))
-        
-        documents = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"key": "value"}
-            }
-        ])
-        
+
+        documents = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": {"key": "value"}}]
+        )
+
         metadata = DatasetMetadata(
             name="test",
             created_at="2021-01-01 00:00:00.000000",
             documents=1,
             queries=0,
-            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+            dense_model=DenseModelMetadata(name="ada2", dimension=2),
         )
-        
-        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
-        
+
+        dataset = Dataset.from_pandas(
+            documents=documents, queries=None, metadata=metadata
+        )
+
         # Mock to cause error during write
         from fsspec.implementations.local import LocalFileSystem
-        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=LocalFileSystem()):
-            with patch('builtins.open', side_effect=IOError("Simulated error")):
+
+        with patch(
+            "pinecone_datasets.dataset_fswriter.get_cloud_fs",
+            return_value=LocalFileSystem(),
+        ):
+            with patch("builtins.open", side_effect=IOError("Simulated error")):
                 with pytest.raises(IOError):
                     DatasetFSWriter.write_dataset(dataset_path, dataset)
-        
+
         # Original dataset should still be intact
         assert dataset.documents is not None
         assert len(dataset.documents) == 1
@@ -539,28 +544,30 @@ class TestIntegrationErrorScenarios:
         dataset_path = str(tmpdir.mkdir("dataset"))
         documents_path = os.path.join(dataset_path, "documents")
         os.makedirs(documents_path)
-        
+
         # Documents with unicode in metadata
-        documents_data = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"text": "日本語", "emoji": "🎉", "chinese": "中文"}
-            }
-        ])
+        documents_data = pd.DataFrame(
+            [
+                {
+                    "id": "1",
+                    "values": [0.1, 0.2],
+                    "metadata": {"text": "日本語", "emoji": "🎉", "chinese": "中文"},
+                }
+            ]
+        )
         documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
-        
+
         metadata = {
             "name": "unicode_dataset",
             "created_at": "2021-01-01 00:00:00.000000",
             "documents": 1,
             "queries": 0,
             "dense_model": {"name": "ada2", "dimension": 2},
-            "description": "データセット with unicode 🌟"
+            "description": "データセット with unicode 🌟",
         }
         with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
             json.dump(metadata, f, ensure_ascii=False)
-        
+
         # Should load successfully
         ds = Dataset.from_path(dataset_path)
         assert len(ds.documents) == 1

--- a/tests/unit/test_catalog_errors.py
+++ b/tests/unit/test_catalog_errors.py
@@ -1,0 +1,460 @@
+import pytest
+import json
+import os
+import pandas as pd
+from unittest.mock import Mock, patch, MagicMock
+
+from pinecone_datasets.catalog import Catalog
+from pinecone_datasets import Dataset, DatasetMetadata, DenseModelMetadata
+
+
+class TestCatalogErrorPaths:
+    """Test error handling in Catalog"""
+
+    def test_load_catalog_network_error(self):
+        """Test loading catalog with network error"""
+        catalog = Catalog(base_path="gs://test-bucket/catalog")
+        
+        mock_fs = Mock()
+        mock_fs.glob.side_effect = IOError("Network connection failed")
+        
+        with patch('pinecone_datasets.catalog.get_cloud_fs', return_value=mock_fs):
+            with pytest.raises(IOError):
+                catalog.load()
+
+    def test_load_catalog_invalid_json(self, tmpdir):
+        """Test loading catalog with corrupted metadata.json"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        dataset_path = os.path.join(catalog_path, "dataset1")
+
+        os.makedirs(dataset_path)
+        
+        # Write invalid JSON
+        with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
+            f.write("{invalid json content")
+        
+        catalog = Catalog(base_path=catalog_path)
+        
+        # Should warn and skip the invalid dataset
+        with pytest.warns(UserWarning, match="Not a JSON"):
+            result = catalog.load()
+            assert len(result.datasets) == 0
+
+    def test_load_catalog_missing_required_fields(self, tmpdir):
+        """Test loading catalog with metadata missing required fields"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        dataset_path = os.path.join(catalog_path, "dataset1")
+
+        os.makedirs(dataset_path)
+        
+        # Write metadata with missing required field
+        incomplete_metadata = {
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": 10,
+            "queries": 5
+        }
+        
+        with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
+            json.dump(incomplete_metadata, f)
+        
+        catalog = Catalog(base_path=catalog_path)
+        
+        # Should warn and skip the invalid dataset
+        with pytest.warns(UserWarning, match="is not valid"):
+            result = catalog.load()
+            assert len(result.datasets) == 0
+
+    def test_load_catalog_permission_denied(self):
+        """Test loading catalog with permission denied"""
+        catalog = Catalog(base_path="/restricted/path")
+        
+        mock_fs = Mock()
+        mock_fs.glob.side_effect = PermissionError("Permission denied")
+        
+        with patch('pinecone_datasets.catalog.get_cloud_fs', return_value=mock_fs):
+            with pytest.raises(PermissionError):
+                catalog.load()
+
+    def test_load_catalog_empty_catalog(self, tmpdir):
+        """Test loading empty catalog"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        catalog = Catalog(base_path=catalog_path)
+        
+        result = catalog.load()
+        assert len(result.datasets) == 0
+
+    def test_load_catalog_no_metadata_files(self, tmpdir):
+        """Test loading catalog with directories but no metadata.json"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        # Create directory without metadata.json
+        dataset_path = os.path.join(catalog_path, "dataset1")
+
+        os.makedirs(dataset_path)
+        
+        catalog = Catalog(base_path=catalog_path)
+        result = catalog.load()
+        assert len(result.datasets) == 0
+
+    def test_list_datasets_auto_load_on_empty(self, tmpdir):
+        """Test that list_datasets auto-loads when datasets is empty"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        dataset_path = os.path.join(catalog_path, "dataset1")
+
+        os.makedirs(dataset_path)
+        
+        # Create valid metadata
+        metadata = {
+            "name": "dataset1",
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": 10,
+            "queries": 5,
+            "dense_model": {"name": "ada2", "dimension": 2}
+        }
+        
+        with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
+            json.dump(metadata, f)
+        
+        catalog = Catalog(base_path=catalog_path)
+        # Don't call load() first
+        result = catalog.list_datasets(as_df=False)
+        assert "dataset1" in result
+
+    def test_load_dataset_nonexistent(self, tmpdir):
+        """Test loading nonexistent dataset"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        catalog = Catalog(base_path=catalog_path)
+        
+        with pytest.raises(FileNotFoundError):
+            catalog.load_dataset("nonexistent_dataset")
+
+    def test_load_dataset_corrupted_data(self, tmpdir):
+        """Test loading dataset with corrupted data"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        dataset_path = os.path.join(catalog_path, "dataset1")
+
+        os.makedirs(dataset_path)
+        
+        # Create metadata
+        metadata = {
+            "name": "dataset1",
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": 10,
+            "queries": 5,
+            "dense_model": {"name": "ada2", "dimension": 2}
+        }
+        
+        with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
+            json.dump(metadata, f)
+        
+        # Create corrupted parquet file
+        documents_path = os.path.join(dataset_path, "documents")
+        os.makedirs(documents_path)
+        with open(os.path.join(documents_path, "part-0.parquet"), "w") as f:
+            f.write("corrupted data")
+        
+        catalog = Catalog(base_path=catalog_path)
+        
+        # Should raise error when trying to load corrupted dataset
+        with pytest.raises(Exception):
+            ds = catalog.load_dataset("dataset1")
+            # Access documents to trigger loading
+            _ = ds.documents
+
+    def test_save_dataset_invalid_path(self):
+        """Test saving dataset to invalid path"""
+        catalog = Catalog(base_path="/invalid/\x00/path")
+        
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        
+        with pytest.raises(Exception):
+            catalog.save_dataset(dataset)
+
+    def test_save_dataset_permission_denied(self, tmpdir):
+        """Test saving dataset with permission denied"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        catalog = Catalog(base_path=catalog_path)
+        
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        
+        # Mock get_cloud_fs to return filesystem that raises permission error
+        mock_fs = Mock()
+        mock_fs.makedirs.side_effect = PermissionError("Permission denied")
+        
+        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=mock_fs):
+            with pytest.raises(PermissionError):
+                catalog.save_dataset(dataset)
+
+    def test_save_dataset_disk_full(self, tmpdir):
+        """Test saving dataset when disk is full"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        catalog = Catalog(base_path=catalog_path)
+        
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        
+        # Mock open to raise disk full error
+        from fsspec.implementations.local import LocalFileSystem
+        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=LocalFileSystem()):
+            with patch('builtins.open', side_effect=OSError("No space left on device")):
+                with pytest.raises(OSError, match="No space left on device"):
+                    catalog.save_dataset(dataset)
+
+    def test_load_catalog_mixed_valid_invalid_datasets(self, tmpdir):
+        """Test loading catalog with mix of valid and invalid datasets"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        
+        # Create valid dataset
+        dataset1_path = dataset_path = os.path.join(catalog_path, "dataset1")
+        os.makedirs(dataset_path)
+        valid_metadata = {
+            "name": "dataset1",
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": 10,
+            "queries": 5,
+            "dense_model": {"name": "ada2", "dimension": 2}
+        }
+        with open(os.path.join(dataset1_path, "metadata.json"), "w") as f:
+            json.dump(valid_metadata, f)
+        
+        # Create invalid dataset (missing required field)
+        dataset2_path = dataset_path = os.path.join(catalog_path, "dataset2")
+        os.makedirs(dataset_path)
+        invalid_metadata = {
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": 10,
+            "queries": 5
+        }
+        with open(os.path.join(dataset2_path, "metadata.json"), "w") as f:
+            json.dump(invalid_metadata, f)
+        
+        catalog = Catalog(base_path=catalog_path)
+        
+        # Should load only valid datasets and warn about invalid ones
+        with pytest.warns(UserWarning):
+            result = catalog.load()
+            assert len(result.datasets) == 1
+            assert result.datasets[0].name == "dataset1"
+
+    def test_load_catalog_file_open_error(self):
+        """Test loading catalog when file cannot be opened"""
+        catalog = Catalog(base_path="gs://test-bucket/catalog")
+        
+        mock_fs = Mock()
+        mock_fs.glob.return_value = ["gs://test-bucket/catalog/dataset1/metadata.json"]
+        mock_fs.open.side_effect = IOError("Cannot open file")
+        
+        with patch('pinecone_datasets.catalog.get_cloud_fs', return_value=mock_fs):
+            with pytest.raises(IOError):
+                catalog.load()
+
+    def test_list_datasets_as_dataframe(self, tmpdir):
+        """Test listing datasets as DataFrame"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        dataset_path = os.path.join(catalog_path, "dataset1")
+
+        os.makedirs(dataset_path)
+        
+        metadata = {
+            "name": "dataset1",
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": 10,
+            "queries": 5,
+            "dense_model": {"name": "ada2", "dimension": 2}
+        }
+        
+        with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
+            json.dump(metadata, f)
+        
+        catalog = Catalog(base_path=catalog_path)
+        result = catalog.list_datasets(as_df=True)
+        
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 1
+        assert "name" in result.columns
+
+    def test_catalog_default_base_path(self):
+        """Test catalog uses default base path from environment or config"""
+        catalog = Catalog()
+        assert catalog.base_path is not None
+
+    def test_catalog_custom_base_path(self):
+        """Test catalog with custom base path"""
+        custom_path = "/custom/path"
+        catalog = Catalog(base_path=custom_path)
+        assert catalog.base_path == custom_path
+
+    def test_load_dataset_missing_metadata(self, tmpdir):
+        """Test loading dataset with missing metadata.json"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        dataset_path = os.path.join(catalog_path, "dataset1")
+
+        os.makedirs(dataset_path)
+        
+        # Create only documents directory, no metadata
+        os.makedirs(os.path.join(dataset_path, "documents"))
+        
+        catalog = Catalog(base_path=catalog_path)
+        
+        with pytest.raises(Exception):
+            ds = catalog.load_dataset("dataset1")
+            # Access metadata to trigger loading
+            _ = ds.metadata
+
+    def test_load_dataset_network_timeout(self):
+        """Test loading dataset with network timeout"""
+        catalog = Catalog(base_path="gs://test-bucket/catalog")
+        
+        mock_ds = Mock(spec=Dataset)
+        mock_ds.from_path.side_effect = TimeoutError("Network timeout")
+        
+        with patch('pinecone_datasets.catalog.Dataset.from_path', side_effect=TimeoutError("Network timeout")):
+            with pytest.raises(TimeoutError):
+                catalog.load_dataset("dataset1")
+
+    def test_save_dataset_network_failure(self, tmpdir):
+        """Test saving dataset with network failure"""
+        catalog_path = "gs://test-bucket/catalog"
+        catalog = Catalog(base_path=catalog_path)
+        
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        
+        # Mock DatasetFSWriter to raise network error
+        with patch('pinecone_datasets.catalog.DatasetFSWriter.write_dataset', side_effect=IOError("Network error")):
+            with pytest.raises(IOError):
+                catalog.save_dataset(dataset)
+
+    def test_load_catalog_empty_metadata_file(self, tmpdir):
+        """Test loading catalog with empty metadata file"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        dataset_path = os.path.join(catalog_path, "dataset1")
+
+        os.makedirs(dataset_path)
+        
+        # Create empty metadata file
+        with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
+            f.write("")
+        
+        catalog = Catalog(base_path=catalog_path)
+        
+        # Should warn and skip the invalid dataset
+        with pytest.warns(UserWarning, match="Not a JSON"):
+            result = catalog.load()
+            assert len(result.datasets) == 0
+
+    def test_load_catalog_metadata_wrong_type(self, tmpdir):
+        """Test loading catalog with metadata of wrong type (list instead of dict)"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        dataset_path = os.path.join(catalog_path, "dataset1")
+
+        os.makedirs(dataset_path)
+        
+        # Write list instead of dict
+        with open(os.path.join(dataset_path, "metadata.json"), "w") as f:
+            json.dump(["not", "a", "dict"], f)
+        
+        catalog = Catalog(base_path=catalog_path)
+        
+        # TypeError is raised when trying to unpack non-dict as **kwargs
+        with pytest.raises(TypeError):
+            catalog.load()
+
+    def test_save_dataset_writes_to_correct_path(self, tmpdir):
+        """Test that save_dataset writes to correct path with dataset name"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        catalog = Catalog(base_path=catalog_path)
+        
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="my_dataset",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        catalog.save_dataset(dataset)
+        
+        # Verify dataset was saved to correct path
+        expected_path = os.path.join(catalog_path, "my_dataset")
+        assert os.path.exists(expected_path)
+        assert os.path.exists(os.path.join(expected_path, "metadata.json"))
+        assert os.path.exists(os.path.join(expected_path, "documents"))
+
+    def test_load_catalog_with_env_variable(self, tmpdir, monkeypatch):
+        """Test catalog uses environment variable for base path"""
+        catalog_path = str(tmpdir.mkdir("catalog"))
+        monkeypatch.setenv("DATASETS_CATALOG_BASEPATH", catalog_path)
+        
+        catalog = Catalog()
+        assert catalog.base_path == catalog_path

--- a/tests/unit/test_catalog_errors.py
+++ b/tests/unit/test_catalog_errors.py
@@ -1,11 +1,12 @@
-import pytest
 import json
 import os
-import pandas as pd
-from unittest.mock import Mock, patch, MagicMock
 
-from pinecone_datasets.catalog import Catalog
+import pandas as pd
+import pytest
+from unittest.mock import Mock, patch
+
 from pinecone_datasets import Dataset, DatasetMetadata, DenseModelMetadata
+from pinecone_datasets.catalog import Catalog
 
 
 class TestCatalogErrorPaths:
@@ -16,10 +17,10 @@ class TestCatalogErrorPaths:
         catalog = Catalog(base_path="gs://test-bucket/catalog")
 
         mock_fs = Mock()
-        mock_fs.glob.side_effect = IOError("Network connection failed")
+        mock_fs.glob.side_effect = OSError("Network connection failed")
 
         with patch("pinecone_datasets.catalog.get_cloud_fs", return_value=mock_fs):
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 catalog.load()
 
     def test_load_catalog_invalid_json(self, tmpdir):
@@ -288,10 +289,10 @@ class TestCatalogErrorPaths:
 
         mock_fs = Mock()
         mock_fs.glob.return_value = ["gs://test-bucket/catalog/dataset1/metadata.json"]
-        mock_fs.open.side_effect = IOError("Cannot open file")
+        mock_fs.open.side_effect = OSError("Cannot open file")
 
         with patch("pinecone_datasets.catalog.get_cloud_fs", return_value=mock_fs):
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 catalog.load()
 
     def test_list_datasets_as_dataframe(self, tmpdir):
@@ -382,9 +383,9 @@ class TestCatalogErrorPaths:
         # Mock DatasetFSWriter to raise network error
         with patch(
             "pinecone_datasets.catalog.DatasetFSWriter.write_dataset",
-            side_effect=IOError("Network error"),
+            side_effect=OSError("Network error"),
         ):
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 catalog.save_dataset(dataset)
 
     def test_load_catalog_empty_metadata_file(self, tmpdir):

--- a/tests/unit/test_catalog_errors.py
+++ b/tests/unit/test_catalog_errors.py
@@ -1,9 +1,9 @@
 import json
 import os
+from unittest.mock import Mock, patch
 
 import pandas as pd
 import pytest
-from unittest.mock import Mock, patch
 
 from pinecone_datasets import Dataset, DatasetMetadata, DenseModelMetadata
 from pinecone_datasets.catalog import Catalog

--- a/tests/unit/test_catalog_errors.py
+++ b/tests/unit/test_catalog_errors.py
@@ -351,9 +351,6 @@ class TestCatalogErrorPaths:
         """Test loading dataset with network timeout"""
         catalog = Catalog(base_path="gs://test-bucket/catalog")
 
-        mock_ds = Mock(spec=Dataset)
-        mock_ds.from_path.side_effect = TimeoutError("Network timeout")
-
         with patch(
             "pinecone_datasets.catalog.Dataset.from_path",
             side_effect=TimeoutError("Network timeout"),

--- a/tests/unit/test_fs_errors.py
+++ b/tests/unit/test_fs_errors.py
@@ -1,6 +1,5 @@
 import pytest
-from unittest.mock import Mock, patch, MagicMock
-from importlib import import_module
+from unittest.mock import Mock, patch
 
 from pinecone_datasets.fs import get_cloud_fs
 

--- a/tests/unit/test_fs_errors.py
+++ b/tests/unit/test_fs_errors.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 
 from pinecone_datasets.fs import get_cloud_fs
 

--- a/tests/unit/test_fs_errors.py
+++ b/tests/unit/test_fs_errors.py
@@ -29,25 +29,25 @@ class TestFSErrorPaths:
 
     def test_get_cloud_fs_s3_import_error(self):
         """Test error when s3fs module cannot be imported"""
-        with patch('pinecone_datasets.fs.import_module') as mock_import:
+        with patch("pinecone_datasets.fs.import_module") as mock_import:
             mock_import.side_effect = ImportError("No module named 's3fs'")
-            
+
             with pytest.raises(ImportError):
                 get_cloud_fs("s3://test-bucket")
 
     def test_get_cloud_fs_gcs_import_error(self):
         """Test error when gcsfs module cannot be imported"""
-        with patch('pinecone_datasets.fs.import_module') as mock_import:
+        with patch("pinecone_datasets.fs.import_module") as mock_import:
             mock_import.side_effect = ImportError("No module named 'gcsfs'")
-            
+
             with pytest.raises(ImportError):
                 get_cloud_fs("gs://test-bucket")
 
     def test_get_cloud_fs_local_import_error(self):
         """Test error when local filesystem module cannot be imported"""
-        with patch('pinecone_datasets.fs.import_module') as mock_import:
+        with patch("pinecone_datasets.fs.import_module") as mock_import:
             mock_import.side_effect = ImportError("No module named 'fsspec'")
-            
+
             with pytest.raises(ImportError):
                 get_cloud_fs("/local/path")
 
@@ -88,6 +88,7 @@ class TestFSErrorPaths:
     def test_get_cloud_fs_gcs_anon_parameter(self):
         """Test GCS filesystem with anon parameter for public bucket"""
         from pinecone_datasets import cfg
+
         # Using the public bucket should set token to "anon"
         fs = get_cloud_fs(cfg.Storage.endpoint)
         assert fs is not None
@@ -99,7 +100,9 @@ class TestFSErrorPaths:
 
     def test_get_cloud_fs_with_custom_kwargs_gcs(self):
         """Test GCS filesystem with custom kwargs"""
-        fs = get_cloud_fs("gs://test-bucket", endpoint_url="https://custom.gcs.endpoint")
+        fs = get_cloud_fs(
+            "gs://test-bucket", endpoint_url="https://custom.gcs.endpoint"
+        )
         assert fs is not None
 
     def test_get_cloud_fs_unsupported_protocol(self):
@@ -130,31 +133,37 @@ class TestFSErrorPaths:
 
     def test_get_cloud_fs_s3_creation_failure(self):
         """Test S3 filesystem creation failure"""
-        with patch('pinecone_datasets.fs.import_module') as mock_import:
+        with patch("pinecone_datasets.fs.import_module") as mock_import:
             mock_s3fs = Mock()
-            mock_s3fs.S3FileSystem.side_effect = Exception("Failed to create filesystem")
+            mock_s3fs.S3FileSystem.side_effect = Exception(
+                "Failed to create filesystem"
+            )
             mock_import.return_value = mock_s3fs
-            
+
             with pytest.raises(Exception, match="Failed to create filesystem"):
                 get_cloud_fs("s3://test-bucket")
 
     def test_get_cloud_fs_gcs_creation_failure(self):
         """Test GCS filesystem creation failure"""
-        with patch('pinecone_datasets.fs.import_module') as mock_import:
+        with patch("pinecone_datasets.fs.import_module") as mock_import:
             mock_gcsfs = Mock()
-            mock_gcsfs.GCSFileSystem.side_effect = Exception("Failed to create filesystem")
+            mock_gcsfs.GCSFileSystem.side_effect = Exception(
+                "Failed to create filesystem"
+            )
             mock_import.return_value = mock_gcsfs
-            
+
             with pytest.raises(Exception, match="Failed to create filesystem"):
                 get_cloud_fs("gs://test-bucket")
 
     def test_get_cloud_fs_local_creation_failure(self):
         """Test local filesystem creation failure"""
-        with patch('pinecone_datasets.fs.import_module') as mock_import:
+        with patch("pinecone_datasets.fs.import_module") as mock_import:
             mock_local = Mock()
-            mock_local.LocalFileSystem.side_effect = Exception("Failed to create filesystem")
+            mock_local.LocalFileSystem.side_effect = Exception(
+                "Failed to create filesystem"
+            )
             mock_import.return_value = mock_local
-            
+
             with pytest.raises(Exception, match="Failed to create filesystem"):
                 get_cloud_fs("/local/path")
 
@@ -259,21 +268,16 @@ class TestFSErrorPaths:
     def test_get_cloud_fs_concurrent_creation(self):
         """Test creating multiple filesystems concurrently"""
         import concurrent.futures
-        
+
         def create_fs(path):
             return get_cloud_fs(path)
-        
-        paths = [
-            "s3://bucket1",
-            "gs://bucket2",
-            "/local/path",
-            "s3://bucket3"
-        ]
-        
+
+        paths = ["s3://bucket1", "gs://bucket2", "/local/path", "s3://bucket3"]
+
         with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
             futures = [executor.submit(create_fs, path) for path in paths]
             results = [f.result() for f in concurrent.futures.as_completed(futures)]
-        
+
         assert all(fs is not None for fs in results)
 
     def test_get_cloud_fs_memory_pressure(self):
@@ -283,6 +287,6 @@ class TestFSErrorPaths:
         for i in range(100):
             fs = get_cloud_fs(f"/local/path/{i}")
             filesystems.append(fs)
-        
+
         assert len(filesystems) == 100
         assert all(fs is not None for fs in filesystems)

--- a/tests/unit/test_fs_errors.py
+++ b/tests/unit/test_fs_errors.py
@@ -1,0 +1,288 @@
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from importlib import import_module
+
+from pinecone_datasets.fs import get_cloud_fs
+
+
+class TestFSErrorPaths:
+    """Test error handling in filesystem abstraction"""
+
+    def test_get_cloud_fs_invalid_s3_credentials(self):
+        """Test getting S3 filesystem with invalid credentials"""
+        # This should create the filesystem object, but actual operations would fail
+        # The function itself doesn't validate credentials
+        fs = get_cloud_fs("s3://test-bucket")
+        assert fs is not None
+
+    def test_get_cloud_fs_invalid_gcs_credentials(self):
+        """Test getting GCS filesystem with invalid credentials"""
+        # This should create the filesystem object, but actual operations would fail
+        fs = get_cloud_fs("gs://test-bucket")
+        assert fs is not None
+
+    def test_get_cloud_fs_with_invalid_token(self):
+        """Test getting cloud filesystem with invalid token parameter"""
+        # Should still create filesystem, token validation happens during operations
+        fs = get_cloud_fs("gs://test-bucket", token="invalid_token")
+        assert fs is not None
+
+    def test_get_cloud_fs_s3_import_error(self):
+        """Test error when s3fs module cannot be imported"""
+        with patch('pinecone_datasets.fs.import_module') as mock_import:
+            mock_import.side_effect = ImportError("No module named 's3fs'")
+            
+            with pytest.raises(ImportError):
+                get_cloud_fs("s3://test-bucket")
+
+    def test_get_cloud_fs_gcs_import_error(self):
+        """Test error when gcsfs module cannot be imported"""
+        with patch('pinecone_datasets.fs.import_module') as mock_import:
+            mock_import.side_effect = ImportError("No module named 'gcsfs'")
+            
+            with pytest.raises(ImportError):
+                get_cloud_fs("gs://test-bucket")
+
+    def test_get_cloud_fs_local_import_error(self):
+        """Test error when local filesystem module cannot be imported"""
+        with patch('pinecone_datasets.fs.import_module') as mock_import:
+            mock_import.side_effect = ImportError("No module named 'fsspec'")
+            
+            with pytest.raises(ImportError):
+                get_cloud_fs("/local/path")
+
+    def test_get_cloud_fs_empty_path(self):
+        """Test getting filesystem with empty path"""
+        fs = get_cloud_fs("")
+        assert fs is not None
+        # Empty path should default to local filesystem
+
+    def test_get_cloud_fs_malformed_s3_url(self):
+        """Test getting filesystem with malformed S3 URL"""
+        # Should still create filesystem, URL validation happens during operations
+        fs = get_cloud_fs("s3://")
+        assert fs is not None
+
+    def test_get_cloud_fs_malformed_gcs_url(self):
+        """Test getting filesystem with malformed GCS URL"""
+        # Should still create filesystem, URL validation happens during operations
+        fs = get_cloud_fs("gs://")
+        assert fs is not None
+
+    def test_get_cloud_fs_s3_with_http_url(self):
+        """Test getting S3 filesystem with HTTP URL"""
+        fs = get_cloud_fs("https://s3.amazonaws.com/bucket/path")
+        assert fs is not None
+
+    def test_get_cloud_fs_gcs_with_http_url(self):
+        """Test getting GCS filesystem with HTTP URL"""
+        fs = get_cloud_fs("https://storage.googleapis.com/bucket/path")
+        assert fs is not None
+
+    def test_get_cloud_fs_s3_anon_parameter(self):
+        """Test S3 filesystem detects public endpoint correctly"""
+        # Test with non-public bucket (anon should be False)
+        fs = get_cloud_fs("s3://test-bucket")
+        assert fs is not None
+
+    def test_get_cloud_fs_gcs_anon_parameter(self):
+        """Test GCS filesystem with anon parameter for public bucket"""
+        from pinecone_datasets import cfg
+        # Using the public bucket should set token to "anon"
+        fs = get_cloud_fs(cfg.Storage.endpoint)
+        assert fs is not None
+
+    def test_get_cloud_fs_with_custom_kwargs_s3(self):
+        """Test S3 filesystem with custom kwargs"""
+        fs = get_cloud_fs("s3://test-bucket", endpoint_url="https://custom.s3.endpoint")
+        assert fs is not None
+
+    def test_get_cloud_fs_with_custom_kwargs_gcs(self):
+        """Test GCS filesystem with custom kwargs"""
+        fs = get_cloud_fs("gs://test-bucket", endpoint_url="https://custom.gcs.endpoint")
+        assert fs is not None
+
+    def test_get_cloud_fs_unsupported_protocol(self):
+        """Test getting filesystem with unsupported protocol"""
+        # FTP protocol not supported, should default to local filesystem
+        fs = get_cloud_fs("ftp://test-server/path")
+        assert fs is not None
+
+    def test_get_cloud_fs_special_characters_in_path(self):
+        """Test getting filesystem with special characters in path"""
+        fs = get_cloud_fs("/path/with/special/chars/@#$/test")
+        assert fs is not None
+
+    def test_get_cloud_fs_unicode_path(self):
+        """Test getting filesystem with unicode characters in path"""
+        fs = get_cloud_fs("/path/with/unicode/日本語/test")
+        assert fs is not None
+
+    def test_get_cloud_fs_relative_path(self):
+        """Test getting filesystem with relative path"""
+        fs = get_cloud_fs("./relative/path")
+        assert fs is not None
+
+    def test_get_cloud_fs_windows_path(self):
+        """Test getting filesystem with Windows-style path"""
+        fs = get_cloud_fs("C:\\Windows\\Path")
+        assert fs is not None
+
+    def test_get_cloud_fs_s3_creation_failure(self):
+        """Test S3 filesystem creation failure"""
+        with patch('pinecone_datasets.fs.import_module') as mock_import:
+            mock_s3fs = Mock()
+            mock_s3fs.S3FileSystem.side_effect = Exception("Failed to create filesystem")
+            mock_import.return_value = mock_s3fs
+            
+            with pytest.raises(Exception, match="Failed to create filesystem"):
+                get_cloud_fs("s3://test-bucket")
+
+    def test_get_cloud_fs_gcs_creation_failure(self):
+        """Test GCS filesystem creation failure"""
+        with patch('pinecone_datasets.fs.import_module') as mock_import:
+            mock_gcsfs = Mock()
+            mock_gcsfs.GCSFileSystem.side_effect = Exception("Failed to create filesystem")
+            mock_import.return_value = mock_gcsfs
+            
+            with pytest.raises(Exception, match="Failed to create filesystem"):
+                get_cloud_fs("gs://test-bucket")
+
+    def test_get_cloud_fs_local_creation_failure(self):
+        """Test local filesystem creation failure"""
+        with patch('pinecone_datasets.fs.import_module') as mock_import:
+            mock_local = Mock()
+            mock_local.LocalFileSystem.side_effect = Exception("Failed to create filesystem")
+            mock_import.return_value = mock_local
+            
+            with pytest.raises(Exception, match="Failed to create filesystem"):
+                get_cloud_fs("/local/path")
+
+    def test_get_cloud_fs_with_none_path(self):
+        """Test getting filesystem with None path"""
+        with pytest.raises(AttributeError):
+            get_cloud_fs(None)
+
+    def test_get_cloud_fs_s3_with_custom_token(self):
+        """Test S3 filesystem ignores token parameter (not applicable to S3)"""
+        fs = get_cloud_fs("s3://test-bucket", token="custom_token")
+        assert fs is not None
+
+    def test_get_cloud_fs_gcs_with_custom_token(self):
+        """Test GCS filesystem with custom token parameter"""
+        fs = get_cloud_fs("gs://test-bucket", token="custom_token")
+        assert fs is not None
+
+    def test_get_cloud_fs_network_unreachable(self):
+        """Test filesystem creation when network is unreachable"""
+        # Filesystem creation usually succeeds, network errors occur during operations
+        fs = get_cloud_fs("s3://unreachable-bucket")
+        assert fs is not None
+
+    def test_get_cloud_fs_dns_resolution_failure(self):
+        """Test filesystem creation with DNS resolution failure"""
+        # Filesystem creation usually succeeds, DNS errors occur during operations
+        fs = get_cloud_fs("s3://nonexistent.domain.invalid/bucket")
+        assert fs is not None
+
+    def test_get_cloud_fs_connection_timeout(self):
+        """Test filesystem creation with connection timeout"""
+        # Filesystem creation usually succeeds, timeout errors occur during operations
+        fs = get_cloud_fs("s3://timeout-bucket")
+        assert fs is not None
+
+    def test_get_cloud_fs_ssl_error(self):
+        """Test filesystem creation with SSL certificate errors"""
+        # Filesystem creation usually succeeds, SSL errors occur during operations
+        fs = get_cloud_fs("https://invalid-cert.example.com")
+        assert fs is not None
+
+    def test_get_cloud_fs_proxy_error(self):
+        """Test filesystem creation with proxy configuration errors"""
+        # Filesystem creation usually succeeds, proxy errors occur during operations
+        fs = get_cloud_fs("s3://test-bucket")
+        assert fs is not None
+
+    def test_get_cloud_fs_s3_region_mismatch(self):
+        """Test S3 filesystem with region mismatch"""
+        # Filesystem creation succeeds, region errors occur during operations
+        fs = get_cloud_fs("s3://us-west-2-bucket")
+        assert fs is not None
+
+    def test_get_cloud_fs_gcs_project_permission_error(self):
+        """Test GCS filesystem with project permission issues"""
+        # Filesystem creation succeeds, permission errors occur during operations
+        fs = get_cloud_fs("gs://restricted-project-bucket")
+        assert fs is not None
+
+    def test_get_cloud_fs_mixed_case_protocol(self):
+        """Test filesystem with mixed case protocol"""
+        fs = get_cloud_fs("S3://test-bucket")
+        # Should default to local filesystem as protocol check is case-sensitive
+        assert fs is not None
+
+    def test_get_cloud_fs_path_with_query_params(self):
+        """Test filesystem with path containing query parameters"""
+        fs = get_cloud_fs("s3://bucket/path?param=value")
+        assert fs is not None
+
+    def test_get_cloud_fs_path_with_fragment(self):
+        """Test filesystem with path containing fragment"""
+        fs = get_cloud_fs("s3://bucket/path#fragment")
+        assert fs is not None
+
+    def test_get_cloud_fs_extremely_long_path(self):
+        """Test filesystem with extremely long path"""
+        long_path = "s3://bucket/" + "a" * 10000
+        fs = get_cloud_fs(long_path)
+        assert fs is not None
+
+    def test_get_cloud_fs_path_traversal_attempt(self):
+        """Test filesystem with path traversal characters"""
+        fs = get_cloud_fs("../../../etc/passwd")
+        assert fs is not None
+
+    def test_get_cloud_fs_null_bytes_in_path(self):
+        """Test filesystem with null bytes in path"""
+        # May raise ValueError or similar depending on implementation
+        try:
+            fs = get_cloud_fs("/path/with/\x00/null")
+            # If it doesn't raise, that's also valid behavior
+        except ValueError:
+            pass  # Expected behavior
+
+    def test_get_cloud_fs_s3_with_credentials_in_url(self):
+        """Test S3 filesystem with credentials embedded in URL"""
+        fs = get_cloud_fs("s3://access_key:secret_key@bucket/path")
+        assert fs is not None
+
+    def test_get_cloud_fs_concurrent_creation(self):
+        """Test creating multiple filesystems concurrently"""
+        import concurrent.futures
+        
+        def create_fs(path):
+            return get_cloud_fs(path)
+        
+        paths = [
+            "s3://bucket1",
+            "gs://bucket2",
+            "/local/path",
+            "s3://bucket3"
+        ]
+        
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+            futures = [executor.submit(create_fs, path) for path in paths]
+            results = [f.result() for f in concurrent.futures.as_completed(futures)]
+        
+        assert all(fs is not None for fs in results)
+
+    def test_get_cloud_fs_memory_pressure(self):
+        """Test filesystem creation under memory pressure"""
+        # Create many filesystem objects to test memory handling
+        filesystems = []
+        for i in range(100):
+            fs = get_cloud_fs(f"/local/path/{i}")
+            filesystems.append(fs)
+        
+        assert len(filesystems) == 100
+        assert all(fs is not None for fs in filesystems)

--- a/tests/unit/test_fs_errors.py
+++ b/tests/unit/test_fs_errors.py
@@ -255,7 +255,7 @@ class TestFSErrorPaths:
         """Test filesystem with null bytes in path"""
         # May raise ValueError or similar depending on implementation
         try:
-            fs = get_cloud_fs("/path/with/\x00/null")
+            get_cloud_fs("/path/with/\x00/null")
             # If it doesn't raise, that's also valid behavior
         except ValueError:
             pass  # Expected behavior

--- a/tests/unit/test_fsreader_errors.py
+++ b/tests/unit/test_fsreader_errors.py
@@ -1,0 +1,353 @@
+import pytest
+import json
+import os
+import pandas as pd
+from unittest.mock import Mock, patch, MagicMock
+import pyarrow.parquet as pq
+import pyarrow as pa
+
+from pinecone_datasets.dataset_fsreader import DatasetFSReader
+from pinecone_datasets.dataset_metadata import DatasetMetadata
+
+
+class TestFSReaderErrorPaths:
+    """Test error handling in DatasetFSReader"""
+
+    def test_read_metadata_file_not_found(self, tmpdir):
+        """Test reading metadata from non-existent file"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        
+        mock_fs = Mock()
+        mock_fs.open.side_effect = FileNotFoundError("metadata.json not found")
+        
+        with pytest.raises(FileNotFoundError):
+            DatasetFSReader.read_metadata(mock_fs, dataset_path)
+
+    def test_read_metadata_invalid_json(self, tmpdir):
+        """Test reading metadata with corrupted JSON"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        metadata_path = os.path.join(dataset_path, "metadata.json")
+        
+        with open(metadata_path, "w") as f:
+            f.write("{invalid json content")
+        
+        from fsspec.implementations.local import LocalFileSystem
+        fs = LocalFileSystem()
+        
+        with pytest.raises(json.JSONDecodeError):
+            DatasetFSReader.read_metadata(fs, dataset_path)
+
+    def test_read_metadata_missing_required_fields(self, tmpdir):
+        """Test reading metadata with missing required fields"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        metadata_path = os.path.join(dataset_path, "metadata.json")
+        
+        # Missing required field 'name'
+        incomplete_metadata = {
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": 10,
+            "queries": 5
+        }
+        
+        with open(metadata_path, "w") as f:
+            json.dump(incomplete_metadata, f)
+        
+        from fsspec.implementations.local import LocalFileSystem
+        fs = LocalFileSystem()
+        
+        with pytest.raises(Exception):  # Pydantic ValidationError
+            DatasetFSReader.read_metadata(fs, dataset_path)
+
+    def test_read_metadata_invalid_field_types(self, tmpdir):
+        """Test reading metadata with invalid field types"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        metadata_path = os.path.join(dataset_path, "metadata.json")
+        
+        # documents should be int, not string
+        invalid_metadata = {
+            "name": "test",
+            "created_at": "2021-01-01 00:00:00.000000",
+            "documents": "not_a_number",
+            "queries": 5,
+            "dense_model": {"name": "ada2", "dimension": 2}
+        }
+        
+        with open(metadata_path, "w") as f:
+            json.dump(invalid_metadata, f)
+        
+        from fsspec.implementations.local import LocalFileSystem
+        fs = LocalFileSystem()
+        
+        with pytest.raises(Exception):  # Pydantic ValidationError
+            DatasetFSReader.read_metadata(fs, dataset_path)
+
+    def test_read_documents_no_parquet_files(self, tmpdir):
+        """Test reading documents when no parquet files exist"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        documents_path = os.path.join(dataset_path, "documents")
+        os.makedirs(documents_path)
+        
+        from fsspec.implementations.local import LocalFileSystem
+        fs = LocalFileSystem()
+        
+        with pytest.raises(ValueError, match="No parquet files found"):
+            DatasetFSReader.read_documents(fs, dataset_path)
+
+    def test_read_documents_missing_required_column(self, tmpdir):
+        """Test reading documents with missing required column"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        documents_path = os.path.join(dataset_path, "documents")
+        os.makedirs(documents_path)
+        
+        # Missing required 'id' column
+        documents_data = pd.DataFrame([
+            {
+                "values": [0.1, 0.2, 0.3],
+                "metadata": {"title": "test"}
+            }
+        ])
+        
+        documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
+        
+        from fsspec.implementations.local import LocalFileSystem
+        fs = LocalFileSystem()
+        
+        with pytest.raises(ValueError, match="not matching Pinecone Datasets Schema"):
+            DatasetFSReader.read_documents(fs, dataset_path)
+
+    def test_read_queries_missing_required_column(self, tmpdir):
+        """Test reading queries with missing required column"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        queries_path = os.path.join(dataset_path, "queries")
+        os.makedirs(queries_path)
+        
+        # Missing required 'vector' column
+        queries_data = pd.DataFrame([
+            {
+                "filter": {"key": "value"},
+                "top_k": 10
+            }
+        ])
+        
+        queries_data.to_parquet(os.path.join(queries_path, "part-0.parquet"))
+        
+        from fsspec.implementations.local import LocalFileSystem
+        fs = LocalFileSystem()
+        
+        with pytest.raises(ValueError, match="not matching Pinecone Datasets Schema"):
+            DatasetFSReader.read_queries(fs, dataset_path)
+
+    def test_convert_metadata_invalid_type(self):
+        """Test metadata conversion with invalid type"""
+        with pytest.raises(TypeError, match="metadata must be a string or dict"):
+            DatasetFSReader._convert_metadata_from_json_to_dict(123)
+
+    def test_convert_metadata_invalid_json_string(self):
+        """Test metadata conversion with invalid JSON string"""
+        with pytest.raises(json.JSONDecodeError):
+            DatasetFSReader._convert_metadata_from_json_to_dict("{invalid json")
+
+    def test_read_documents_corrupted_parquet(self, tmpdir):
+        """Test reading documents with corrupted parquet file"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        documents_path = os.path.join(dataset_path, "documents")
+        os.makedirs(documents_path)
+        
+        # Write corrupted parquet file
+        corrupted_file = os.path.join(documents_path, "part-0.parquet")
+        with open(corrupted_file, "w") as f:
+            f.write("This is not a valid parquet file")
+        
+        from fsspec.implementations.local import LocalFileSystem
+        fs = LocalFileSystem()
+        
+        with pytest.raises(Exception):  # pyarrow will raise an error
+            DatasetFSReader.read_documents(fs, dataset_path)
+
+    def test_read_queries_corrupted_parquet(self, tmpdir):
+        """Test reading queries with corrupted parquet file"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        queries_path = os.path.join(dataset_path, "queries")
+        os.makedirs(queries_path)
+        
+        # Write corrupted parquet file
+        corrupted_file = os.path.join(queries_path, "part-0.parquet")
+        with open(corrupted_file, "w") as f:
+            f.write("This is not a valid parquet file")
+        
+        from fsspec.implementations.local import LocalFileSystem
+        fs = LocalFileSystem()
+        
+        with pytest.raises(Exception):  # pyarrow will raise an error
+            DatasetFSReader.read_queries(fs, dataset_path)
+
+    def test_read_documents_empty_parquet(self, tmpdir):
+        """Test reading documents from empty parquet files"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        documents_path = os.path.join(dataset_path, "documents")
+        os.makedirs(documents_path)
+        
+        # Create valid but empty dataframe
+        empty_df = pd.DataFrame(columns=["id", "values", "metadata"])
+        empty_df.to_parquet(os.path.join(documents_path, "part-0.parquet"))
+        
+        from fsspec.implementations.local import LocalFileSystem
+        fs = LocalFileSystem()
+        
+        # Should not raise error but return valid dataframe with proper columns
+        result = DatasetFSReader.read_documents(fs, dataset_path)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 0
+        assert "id" in result.columns
+        assert "values" in result.columns
+
+    def test_read_documents_path_does_not_exist(self, tmpdir):
+        """Test reading documents when path doesn't exist"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        
+        from fsspec.implementations.local import LocalFileSystem
+        fs = LocalFileSystem()
+        
+        # Should return empty dataframe with warning
+        with pytest.warns(UserWarning, match="No data found"):
+            result = DatasetFSReader.read_documents(fs, dataset_path)
+            assert isinstance(result, pd.DataFrame)
+            assert len(result) == 0
+
+    def test_read_queries_path_does_not_exist(self, tmpdir):
+        """Test reading queries when path doesn't exist"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        
+        from fsspec.implementations.local import LocalFileSystem
+        fs = LocalFileSystem()
+        
+        # Should return empty dataframe with warning
+        with pytest.warns(UserWarning, match="No data found"):
+            result = DatasetFSReader.read_queries(fs, dataset_path)
+            assert isinstance(result, pd.DataFrame)
+            assert len(result) == 0
+
+    def test_read_documents_permission_denied(self, tmpdir):
+        """Test reading documents with permission denied"""
+        mock_fs = Mock()
+        mock_fs.glob.return_value = ["path/to/file.parquet"]
+        mock_fs.exists.return_value = True
+        
+        # Simulate permission error
+        with patch('pyarrow.parquet.read_pandas') as mock_read:
+            mock_read.side_effect = PermissionError("Permission denied")
+            
+            with pytest.raises(PermissionError):
+                DatasetFSReader.read_documents(mock_fs, "/test/path")
+
+    def test_read_metadata_permission_denied(self, tmpdir):
+        """Test reading metadata with permission denied"""
+        mock_fs = Mock()
+        mock_fs.open.side_effect = PermissionError("Permission denied")
+        
+        with pytest.raises(PermissionError):
+            DatasetFSReader.read_metadata(mock_fs, "/test/path")
+
+    def test_read_documents_network_error(self):
+        """Test reading documents with simulated network error"""
+        mock_fs = Mock()
+        mock_fs.glob.return_value = ["gs://bucket/dataset/documents/part-0.parquet"]
+        mock_fs.exists.return_value = True
+        
+        # Simulate network error
+        with patch('pyarrow.parquet.read_pandas') as mock_read:
+            mock_read.side_effect = IOError("Network connection failed")
+            
+            with pytest.raises(IOError):
+                DatasetFSReader.read_documents(mock_fs, "gs://bucket/dataset")
+
+    def test_read_metadata_network_error(self):
+        """Test reading metadata with simulated network error"""
+        mock_fs = Mock()
+        mock_fs.open.side_effect = IOError("Network connection failed")
+        
+        with pytest.raises(IOError):
+            DatasetFSReader.read_metadata(mock_fs, "gs://bucket/dataset")
+
+    def test_convert_metadata_null_value(self):
+        """Test metadata conversion with None value"""
+        result = DatasetFSReader._convert_metadata_from_json_to_dict(None)
+        assert result is None
+
+    def test_convert_metadata_valid_dict(self):
+        """Test metadata conversion with valid dict"""
+        test_dict = {"key": "value", "number": 123}
+        result = DatasetFSReader._convert_metadata_from_json_to_dict(test_dict)
+        assert result == test_dict
+
+    def test_convert_metadata_valid_json_string(self):
+        """Test metadata conversion with valid JSON string"""
+        test_dict = {"key": "value", "number": 123}
+        json_str = json.dumps(test_dict)
+        result = DatasetFSReader._convert_metadata_from_json_to_dict(json_str)
+        assert result == test_dict
+
+    def test_read_documents_multiple_parquet_files_one_corrupted(self, tmpdir):
+        """Test reading when one of multiple parquet files is corrupted"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        documents_path = os.path.join(dataset_path, "documents")
+        os.makedirs(documents_path)
+        
+        # Write one valid parquet file
+        valid_data = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"title": "test"}
+            }
+        ])
+        valid_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
+        
+        # Write one corrupted parquet file
+        with open(os.path.join(documents_path, "part-1.parquet"), "w") as f:
+            f.write("corrupted data")
+        
+        from fsspec.implementations.local import LocalFileSystem
+        fs = LocalFileSystem()
+        
+        # Should raise error when trying to read corrupted file
+        with pytest.raises(Exception):
+            DatasetFSReader.read_documents(fs, dataset_path)
+
+    def test_read_metadata_empty_file(self, tmpdir):
+        """Test reading metadata from empty file"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        metadata_path = os.path.join(dataset_path, "metadata.json")
+        
+        # Create empty file
+        with open(metadata_path, "w") as f:
+            f.write("")
+        
+        from fsspec.implementations.local import LocalFileSystem
+        fs = LocalFileSystem()
+        
+        with pytest.raises(json.JSONDecodeError):
+            DatasetFSReader.read_metadata(fs, dataset_path)
+
+    def test_read_documents_with_invalid_metadata_json_in_parquet(self, tmpdir):
+        """Test reading documents when metadata field contains invalid JSON"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        documents_path = os.path.join(dataset_path, "documents")
+        os.makedirs(documents_path)
+        
+        # Create parquet with metadata as invalid JSON string
+        documents_data = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": "{invalid json"  # Invalid JSON string
+            }
+        ])
+        documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
+        
+        from fsspec.implementations.local import LocalFileSystem
+        fs = LocalFileSystem()
+        
+        # Should raise JSONDecodeError when trying to convert metadata
+        with pytest.raises(json.JSONDecodeError):
+            DatasetFSReader.read_documents(fs, dataset_path)

--- a/tests/unit/test_fsreader_errors.py
+++ b/tests/unit/test_fsreader_errors.py
@@ -16,10 +16,10 @@ class TestFSReaderErrorPaths:
     def test_read_metadata_file_not_found(self, tmpdir):
         """Test reading metadata from non-existent file"""
         dataset_path = str(tmpdir.mkdir("dataset"))
-        
+
         mock_fs = Mock()
         mock_fs.open.side_effect = FileNotFoundError("metadata.json not found")
-        
+
         with pytest.raises(FileNotFoundError):
             DatasetFSReader.read_metadata(mock_fs, dataset_path)
 
@@ -27,13 +27,14 @@ class TestFSReaderErrorPaths:
         """Test reading metadata with corrupted JSON"""
         dataset_path = str(tmpdir.mkdir("dataset"))
         metadata_path = os.path.join(dataset_path, "metadata.json")
-        
+
         with open(metadata_path, "w") as f:
             f.write("{invalid json content")
-        
+
         from fsspec.implementations.local import LocalFileSystem
+
         fs = LocalFileSystem()
-        
+
         with pytest.raises(json.JSONDecodeError):
             DatasetFSReader.read_metadata(fs, dataset_path)
 
@@ -41,20 +42,21 @@ class TestFSReaderErrorPaths:
         """Test reading metadata with missing required fields"""
         dataset_path = str(tmpdir.mkdir("dataset"))
         metadata_path = os.path.join(dataset_path, "metadata.json")
-        
+
         # Missing required field 'name'
         incomplete_metadata = {
             "created_at": "2021-01-01 00:00:00.000000",
             "documents": 10,
-            "queries": 5
+            "queries": 5,
         }
-        
+
         with open(metadata_path, "w") as f:
             json.dump(incomplete_metadata, f)
-        
+
         from fsspec.implementations.local import LocalFileSystem
+
         fs = LocalFileSystem()
-        
+
         with pytest.raises(Exception):  # Pydantic ValidationError
             DatasetFSReader.read_metadata(fs, dataset_path)
 
@@ -62,22 +64,23 @@ class TestFSReaderErrorPaths:
         """Test reading metadata with invalid field types"""
         dataset_path = str(tmpdir.mkdir("dataset"))
         metadata_path = os.path.join(dataset_path, "metadata.json")
-        
+
         # documents should be int, not string
         invalid_metadata = {
             "name": "test",
             "created_at": "2021-01-01 00:00:00.000000",
             "documents": "not_a_number",
             "queries": 5,
-            "dense_model": {"name": "ada2", "dimension": 2}
+            "dense_model": {"name": "ada2", "dimension": 2},
         }
-        
+
         with open(metadata_path, "w") as f:
             json.dump(invalid_metadata, f)
-        
+
         from fsspec.implementations.local import LocalFileSystem
+
         fs = LocalFileSystem()
-        
+
         with pytest.raises(Exception):  # Pydantic ValidationError
             DatasetFSReader.read_metadata(fs, dataset_path)
 
@@ -86,10 +89,11 @@ class TestFSReaderErrorPaths:
         dataset_path = str(tmpdir.mkdir("dataset"))
         documents_path = os.path.join(dataset_path, "documents")
         os.makedirs(documents_path)
-        
+
         from fsspec.implementations.local import LocalFileSystem
+
         fs = LocalFileSystem()
-        
+
         with pytest.raises(ValueError, match="No parquet files found"):
             DatasetFSReader.read_documents(fs, dataset_path)
 
@@ -98,20 +102,18 @@ class TestFSReaderErrorPaths:
         dataset_path = str(tmpdir.mkdir("dataset"))
         documents_path = os.path.join(dataset_path, "documents")
         os.makedirs(documents_path)
-        
+
         # Missing required 'id' column
-        documents_data = pd.DataFrame([
-            {
-                "values": [0.1, 0.2, 0.3],
-                "metadata": {"title": "test"}
-            }
-        ])
-        
+        documents_data = pd.DataFrame(
+            [{"values": [0.1, 0.2, 0.3], "metadata": {"title": "test"}}]
+        )
+
         documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
-        
+
         from fsspec.implementations.local import LocalFileSystem
+
         fs = LocalFileSystem()
-        
+
         with pytest.raises(ValueError, match="not matching Pinecone Datasets Schema"):
             DatasetFSReader.read_documents(fs, dataset_path)
 
@@ -120,20 +122,16 @@ class TestFSReaderErrorPaths:
         dataset_path = str(tmpdir.mkdir("dataset"))
         queries_path = os.path.join(dataset_path, "queries")
         os.makedirs(queries_path)
-        
+
         # Missing required 'vector' column
-        queries_data = pd.DataFrame([
-            {
-                "filter": {"key": "value"},
-                "top_k": 10
-            }
-        ])
-        
+        queries_data = pd.DataFrame([{"filter": {"key": "value"}, "top_k": 10}])
+
         queries_data.to_parquet(os.path.join(queries_path, "part-0.parquet"))
-        
+
         from fsspec.implementations.local import LocalFileSystem
+
         fs = LocalFileSystem()
-        
+
         with pytest.raises(ValueError, match="not matching Pinecone Datasets Schema"):
             DatasetFSReader.read_queries(fs, dataset_path)
 
@@ -152,15 +150,16 @@ class TestFSReaderErrorPaths:
         dataset_path = str(tmpdir.mkdir("dataset"))
         documents_path = os.path.join(dataset_path, "documents")
         os.makedirs(documents_path)
-        
+
         # Write corrupted parquet file
         corrupted_file = os.path.join(documents_path, "part-0.parquet")
         with open(corrupted_file, "w") as f:
             f.write("This is not a valid parquet file")
-        
+
         from fsspec.implementations.local import LocalFileSystem
+
         fs = LocalFileSystem()
-        
+
         with pytest.raises(Exception):  # pyarrow will raise an error
             DatasetFSReader.read_documents(fs, dataset_path)
 
@@ -169,15 +168,16 @@ class TestFSReaderErrorPaths:
         dataset_path = str(tmpdir.mkdir("dataset"))
         queries_path = os.path.join(dataset_path, "queries")
         os.makedirs(queries_path)
-        
+
         # Write corrupted parquet file
         corrupted_file = os.path.join(queries_path, "part-0.parquet")
         with open(corrupted_file, "w") as f:
             f.write("This is not a valid parquet file")
-        
+
         from fsspec.implementations.local import LocalFileSystem
+
         fs = LocalFileSystem()
-        
+
         with pytest.raises(Exception):  # pyarrow will raise an error
             DatasetFSReader.read_queries(fs, dataset_path)
 
@@ -186,14 +186,15 @@ class TestFSReaderErrorPaths:
         dataset_path = str(tmpdir.mkdir("dataset"))
         documents_path = os.path.join(dataset_path, "documents")
         os.makedirs(documents_path)
-        
+
         # Create valid but empty dataframe
         empty_df = pd.DataFrame(columns=["id", "values", "metadata"])
         empty_df.to_parquet(os.path.join(documents_path, "part-0.parquet"))
-        
+
         from fsspec.implementations.local import LocalFileSystem
+
         fs = LocalFileSystem()
-        
+
         # Should not raise error but return valid dataframe with proper columns
         result = DatasetFSReader.read_documents(fs, dataset_path)
         assert isinstance(result, pd.DataFrame)
@@ -204,10 +205,11 @@ class TestFSReaderErrorPaths:
     def test_read_documents_path_does_not_exist(self, tmpdir):
         """Test reading documents when path doesn't exist"""
         dataset_path = str(tmpdir.mkdir("dataset"))
-        
+
         from fsspec.implementations.local import LocalFileSystem
+
         fs = LocalFileSystem()
-        
+
         # Should return empty dataframe with warning
         with pytest.warns(UserWarning, match="No data found"):
             result = DatasetFSReader.read_documents(fs, dataset_path)
@@ -217,10 +219,11 @@ class TestFSReaderErrorPaths:
     def test_read_queries_path_does_not_exist(self, tmpdir):
         """Test reading queries when path doesn't exist"""
         dataset_path = str(tmpdir.mkdir("dataset"))
-        
+
         from fsspec.implementations.local import LocalFileSystem
+
         fs = LocalFileSystem()
-        
+
         # Should return empty dataframe with warning
         with pytest.warns(UserWarning, match="No data found"):
             result = DatasetFSReader.read_queries(fs, dataset_path)
@@ -232,11 +235,11 @@ class TestFSReaderErrorPaths:
         mock_fs = Mock()
         mock_fs.glob.return_value = ["path/to/file.parquet"]
         mock_fs.exists.return_value = True
-        
+
         # Simulate permission error
-        with patch('pyarrow.parquet.read_pandas') as mock_read:
+        with patch("pyarrow.parquet.read_pandas") as mock_read:
             mock_read.side_effect = PermissionError("Permission denied")
-            
+
             with pytest.raises(PermissionError):
                 DatasetFSReader.read_documents(mock_fs, "/test/path")
 
@@ -244,7 +247,7 @@ class TestFSReaderErrorPaths:
         """Test reading metadata with permission denied"""
         mock_fs = Mock()
         mock_fs.open.side_effect = PermissionError("Permission denied")
-        
+
         with pytest.raises(PermissionError):
             DatasetFSReader.read_metadata(mock_fs, "/test/path")
 
@@ -253,11 +256,11 @@ class TestFSReaderErrorPaths:
         mock_fs = Mock()
         mock_fs.glob.return_value = ["gs://bucket/dataset/documents/part-0.parquet"]
         mock_fs.exists.return_value = True
-        
+
         # Simulate network error
-        with patch('pyarrow.parquet.read_pandas') as mock_read:
+        with patch("pyarrow.parquet.read_pandas") as mock_read:
             mock_read.side_effect = IOError("Network connection failed")
-            
+
             with pytest.raises(IOError):
                 DatasetFSReader.read_documents(mock_fs, "gs://bucket/dataset")
 
@@ -265,7 +268,7 @@ class TestFSReaderErrorPaths:
         """Test reading metadata with simulated network error"""
         mock_fs = Mock()
         mock_fs.open.side_effect = IOError("Network connection failed")
-        
+
         with pytest.raises(IOError):
             DatasetFSReader.read_metadata(mock_fs, "gs://bucket/dataset")
 
@@ -292,24 +295,21 @@ class TestFSReaderErrorPaths:
         dataset_path = str(tmpdir.mkdir("dataset"))
         documents_path = os.path.join(dataset_path, "documents")
         os.makedirs(documents_path)
-        
+
         # Write one valid parquet file
-        valid_data = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"title": "test"}
-            }
-        ])
+        valid_data = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": {"title": "test"}}]
+        )
         valid_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
-        
+
         # Write one corrupted parquet file
         with open(os.path.join(documents_path, "part-1.parquet"), "w") as f:
             f.write("corrupted data")
-        
+
         from fsspec.implementations.local import LocalFileSystem
+
         fs = LocalFileSystem()
-        
+
         # Should raise error when trying to read corrupted file
         with pytest.raises(Exception):
             DatasetFSReader.read_documents(fs, dataset_path)
@@ -318,14 +318,15 @@ class TestFSReaderErrorPaths:
         """Test reading metadata from empty file"""
         dataset_path = str(tmpdir.mkdir("dataset"))
         metadata_path = os.path.join(dataset_path, "metadata.json")
-        
+
         # Create empty file
         with open(metadata_path, "w") as f:
             f.write("")
-        
+
         from fsspec.implementations.local import LocalFileSystem
+
         fs = LocalFileSystem()
-        
+
         with pytest.raises(json.JSONDecodeError):
             DatasetFSReader.read_metadata(fs, dataset_path)
 
@@ -334,20 +335,23 @@ class TestFSReaderErrorPaths:
         dataset_path = str(tmpdir.mkdir("dataset"))
         documents_path = os.path.join(dataset_path, "documents")
         os.makedirs(documents_path)
-        
+
         # Create parquet with metadata as invalid JSON string
-        documents_data = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": "{invalid json"  # Invalid JSON string
-            }
-        ])
+        documents_data = pd.DataFrame(
+            [
+                {
+                    "id": "1",
+                    "values": [0.1, 0.2],
+                    "metadata": "{invalid json",  # Invalid JSON string
+                }
+            ]
+        )
         documents_data.to_parquet(os.path.join(documents_path, "part-0.parquet"))
-        
+
         from fsspec.implementations.local import LocalFileSystem
+
         fs = LocalFileSystem()
-        
+
         # Should raise JSONDecodeError when trying to convert metadata
         with pytest.raises(json.JSONDecodeError):
             DatasetFSReader.read_documents(fs, dataset_path)

--- a/tests/unit/test_fsreader_errors.py
+++ b/tests/unit/test_fsreader_errors.py
@@ -1,10 +1,11 @@
-import pytest
 import json
 import os
+from unittest.mock import Mock, patch
+
 import pandas as pd
-from unittest.mock import Mock, patch, MagicMock
-import pyarrow.parquet as pq
 import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
 
 from pinecone_datasets.dataset_fsreader import DatasetFSReader
 from pinecone_datasets.dataset_metadata import DatasetMetadata

--- a/tests/unit/test_fsreader_errors.py
+++ b/tests/unit/test_fsreader_errors.py
@@ -3,12 +3,9 @@ import os
 from unittest.mock import Mock, patch
 
 import pandas as pd
-import pyarrow as pa
-import pyarrow.parquet as pq
 import pytest
 
 from pinecone_datasets.dataset_fsreader import DatasetFSReader
-from pinecone_datasets.dataset_metadata import DatasetMetadata
 
 
 class TestFSReaderErrorPaths:
@@ -260,17 +257,17 @@ class TestFSReaderErrorPaths:
 
         # Simulate network error
         with patch("pyarrow.parquet.read_pandas") as mock_read:
-            mock_read.side_effect = IOError("Network connection failed")
+            mock_read.side_effect = OSError("Network connection failed")
 
-            with pytest.raises(IOError):
+            with pytest.raises(OSError):
                 DatasetFSReader.read_documents(mock_fs, "gs://bucket/dataset")
 
     def test_read_metadata_network_error(self):
         """Test reading metadata with simulated network error"""
         mock_fs = Mock()
-        mock_fs.open.side_effect = IOError("Network connection failed")
+        mock_fs.open.side_effect = OSError("Network connection failed")
 
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             DatasetFSReader.read_metadata(mock_fs, "gs://bucket/dataset")
 
     def test_convert_metadata_null_value(self):

--- a/tests/unit/test_fswriter_errors.py
+++ b/tests/unit/test_fswriter_errors.py
@@ -14,60 +14,62 @@ class TestFSWriterErrorPaths:
     def test_write_dataset_permission_denied(self, tmpdir):
         """Test writing dataset with permission denied"""
         dataset_path = str(tmpdir.mkdir("dataset"))
-        
+
         # Create a valid dataset
-        documents = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"key": "value"}
-            }
-        ])
-        
+        documents = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": {"key": "value"}}]
+        )
+
         metadata = DatasetMetadata(
             name="test",
             created_at="2021-01-01 00:00:00.000000",
             documents=1,
             queries=0,
-            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+            dense_model=DenseModelMetadata(name="ada2", dimension=2),
         )
-        
-        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
-        
+
+        dataset = Dataset.from_pandas(
+            documents=documents, queries=None, metadata=metadata
+        )
+
         # Mock filesystem with permission error
         mock_fs = Mock()
         mock_fs.makedirs.side_effect = PermissionError("Permission denied")
-        
-        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=mock_fs):
+
+        with patch(
+            "pinecone_datasets.dataset_fswriter.get_cloud_fs", return_value=mock_fs
+        ):
             with pytest.raises(PermissionError):
                 DatasetFSWriter.write_dataset(dataset_path, dataset)
 
     def test_write_dataset_disk_full(self, tmpdir):
         """Test writing dataset when disk is full"""
         dataset_path = str(tmpdir.mkdir("dataset"))
-        
-        documents = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"key": "value"}
-            }
-        ])
-        
+
+        documents = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": {"key": "value"}}]
+        )
+
         metadata = DatasetMetadata(
             name="test",
             created_at="2021-01-01 00:00:00.000000",
             documents=1,
             queries=0,
-            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+            dense_model=DenseModelMetadata(name="ada2", dimension=2),
         )
-        
-        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
-        
+
+        dataset = Dataset.from_pandas(
+            documents=documents, queries=None, metadata=metadata
+        )
+
         # Mock open to raise disk full error
         from fsspec.implementations.local import LocalFileSystem
-        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=LocalFileSystem()):
-            with patch('builtins.open', side_effect=OSError("No space left on device")):
+
+        with patch(
+            "pinecone_datasets.dataset_fswriter.get_cloud_fs",
+            return_value=LocalFileSystem(),
+        ):
+            with patch("builtins.open", side_effect=OSError("No space left on device")):
                 with pytest.raises(OSError, match="No space left on device"):
                     DatasetFSWriter.write_dataset(dataset_path, dataset)
 
@@ -96,91 +98,95 @@ class TestFSWriterErrorPaths:
 
     def test_convert_metadata_nan_value(self):
         """Test metadata conversion with NaN value"""
-        result = DatasetFSWriter._convert_metadata_from_dict_to_json(float('nan'))
+        result = DatasetFSWriter._convert_metadata_from_dict_to_json(float("nan"))
         assert result is None
 
     def test_write_documents_network_error(self, tmpdir):
         """Test writing documents with network error"""
         dataset_path = str(tmpdir.mkdir("dataset"))
-        
-        documents = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"key": "value"}
-            }
-        ])
-        
+
+        documents = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": {"key": "value"}}]
+        )
+
         metadata = DatasetMetadata(
             name="test",
             created_at="2021-01-01 00:00:00.000000",
             documents=1,
             queries=0,
-            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+            dense_model=DenseModelMetadata(name="ada2", dimension=2),
         )
-        
-        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
-        
+
+        dataset = Dataset.from_pandas(
+            documents=documents, queries=None, metadata=metadata
+        )
+
         # Mock filesystem with network error
         mock_fs = Mock()
         mock_fs.makedirs.return_value = None
-        
+
         # Mock to_parquet to raise network error
-        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=mock_fs):
-            with patch.object(pd.DataFrame, 'to_parquet', side_effect=IOError("Network error")):
+        with patch(
+            "pinecone_datasets.dataset_fswriter.get_cloud_fs", return_value=mock_fs
+        ):
+            with patch.object(
+                pd.DataFrame, "to_parquet", side_effect=IOError("Network error")
+            ):
                 with pytest.raises(IOError):
                     DatasetFSWriter.write_dataset(dataset_path, dataset)
 
     def test_write_metadata_invalid_json_serialization(self, tmpdir):
         """Test writing metadata that cannot be JSON serialized"""
         dataset_path = str(tmpdir.mkdir("dataset"))
-        
-        documents = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"key": "value"}
-            }
-        ])
-        
+
+        documents = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": {"key": "value"}}]
+        )
+
         # Create metadata with non-serializable object
         metadata = DatasetMetadata(
             name="test",
             created_at="2021-01-01 00:00:00.000000",
             documents=1,
             queries=0,
-            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+            dense_model=DenseModelMetadata(name="ada2", dimension=2),
         )
-        
-        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
-        
+
+        dataset = Dataset.from_pandas(
+            documents=documents, queries=None, metadata=metadata
+        )
+
         # Mock model_dump to return non-serializable data
-        with patch.object(DatasetMetadata, 'model_dump', return_value={"func": lambda x: x}):
+        with patch.object(
+            DatasetMetadata, "model_dump", return_value={"func": lambda x: x}
+        ):
             from fsspec.implementations.local import LocalFileSystem
-            with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=LocalFileSystem()):
+
+            with patch(
+                "pinecone_datasets.dataset_fswriter.get_cloud_fs",
+                return_value=LocalFileSystem(),
+            ):
                 with pytest.raises(TypeError):
                     DatasetFSWriter.write_dataset(dataset_path, dataset)
 
     def test_write_dataset_invalid_path(self):
         """Test writing dataset to invalid path"""
-        documents = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"key": "value"}
-            }
-        ])
-        
+        documents = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": {"key": "value"}}]
+        )
+
         metadata = DatasetMetadata(
             name="test",
             created_at="2021-01-01 00:00:00.000000",
             documents=1,
             queries=0,
-            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+            dense_model=DenseModelMetadata(name="ada2", dimension=2),
         )
-        
-        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
-        
+
+        dataset = Dataset.from_pandas(
+            documents=documents, queries=None, metadata=metadata
+        )
+
         # Try to write to invalid path
         with pytest.raises(Exception):  # Could be various errors depending on OS
             DatasetFSWriter.write_dataset("/invalid/\x00/path", dataset)
@@ -188,152 +194,160 @@ class TestFSWriterErrorPaths:
     def test_write_documents_readonly_filesystem(self, tmpdir):
         """Test writing documents to read-only filesystem"""
         dataset_path = str(tmpdir.mkdir("dataset"))
-        
-        documents = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"key": "value"}
-            }
-        ])
-        
+
+        documents = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": {"key": "value"}}]
+        )
+
         metadata = DatasetMetadata(
             name="test",
             created_at="2021-01-01 00:00:00.000000",
             documents=1,
             queries=0,
-            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+            dense_model=DenseModelMetadata(name="ada2", dimension=2),
         )
-        
-        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
-        
+
+        dataset = Dataset.from_pandas(
+            documents=documents, queries=None, metadata=metadata
+        )
+
         # Mock filesystem as read-only
         mock_fs = Mock()
         mock_fs.makedirs.side_effect = OSError("Read-only file system")
-        
-        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=mock_fs):
+
+        with patch(
+            "pinecone_datasets.dataset_fswriter.get_cloud_fs", return_value=mock_fs
+        ):
             with pytest.raises(OSError, match="Read-only file system"):
                 DatasetFSWriter.write_dataset(dataset_path, dataset)
 
     def test_write_queries_with_invalid_filter_type(self, tmpdir):
         """Test writing queries with invalid filter type"""
         dataset_path = str(tmpdir.mkdir("dataset"))
-        
-        documents = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"key": "value"}
-            }
-        ])
-        
+
+        documents = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": {"key": "value"}}]
+        )
+
         # Queries with invalid filter type (should be dict)
-        queries = pd.DataFrame([
-            {
-                "vector": [0.1, 0.2],
-                "filter": "invalid_filter_type",  # Should be dict
-                "top_k": 10
-            }
-        ])
-        
+        queries = pd.DataFrame(
+            [
+                {
+                    "vector": [0.1, 0.2],
+                    "filter": "invalid_filter_type",  # Should be dict
+                    "top_k": 10,
+                }
+            ]
+        )
+
         metadata = DatasetMetadata(
             name="test",
             created_at="2021-01-01 00:00:00.000000",
             documents=1,
             queries=1,
-            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+            dense_model=DenseModelMetadata(name="ada2", dimension=2),
         )
-        
-        dataset = Dataset.from_pandas(documents=documents, queries=queries, metadata=metadata)
-        
+
+        dataset = Dataset.from_pandas(
+            documents=documents, queries=queries, metadata=metadata
+        )
+
         from fsspec.implementations.local import LocalFileSystem
-        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=LocalFileSystem()):
+
+        with patch(
+            "pinecone_datasets.dataset_fswriter.get_cloud_fs",
+            return_value=LocalFileSystem(),
+        ):
             with pytest.raises(TypeError):
                 DatasetFSWriter.write_dataset(dataset_path, dataset)
 
     def test_write_empty_queries_warning(self, tmpdir):
         """Test that writing empty queries produces a warning"""
         dataset_path = str(tmpdir.mkdir("dataset"))
-        
-        documents = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"key": "value"}
-            }
-        ])
-        
+
+        documents = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": {"key": "value"}}]
+        )
+
         metadata = DatasetMetadata(
             name="test",
             created_at="2021-01-01 00:00:00.000000",
             documents=1,
             queries=0,
-            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+            dense_model=DenseModelMetadata(name="ada2", dimension=2),
         )
-        
-        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
-        
+
+        dataset = Dataset.from_pandas(
+            documents=documents, queries=None, metadata=metadata
+        )
+
         from fsspec.implementations.local import LocalFileSystem
-        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=LocalFileSystem()):
+
+        with patch(
+            "pinecone_datasets.dataset_fswriter.get_cloud_fs",
+            return_value=LocalFileSystem(),
+        ):
             with pytest.warns(UserWarning, match="Queries are empty"):
                 DatasetFSWriter.write_dataset(dataset_path, dataset)
 
     def test_write_metadata_file_open_error(self, tmpdir):
         """Test writing metadata when file cannot be opened"""
         dataset_path = str(tmpdir.mkdir("dataset"))
-        
-        documents = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"key": "value"}
-            }
-        ])
-        
+
+        documents = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": {"key": "value"}}]
+        )
+
         metadata = DatasetMetadata(
             name="test",
             created_at="2021-01-01 00:00:00.000000",
             documents=1,
             queries=0,
-            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+            dense_model=DenseModelMetadata(name="ada2", dimension=2),
         )
-        
-        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
-        
+
+        dataset = Dataset.from_pandas(
+            documents=documents, queries=None, metadata=metadata
+        )
+
         # Mock open to fail when writing metadata
         from fsspec.implementations.local import LocalFileSystem
-        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=LocalFileSystem()):
-            with patch('builtins.open', side_effect=IOError("Cannot open file")):
+
+        with patch(
+            "pinecone_datasets.dataset_fswriter.get_cloud_fs",
+            return_value=LocalFileSystem(),
+        ):
+            with patch("builtins.open", side_effect=IOError("Cannot open file")):
                 with pytest.raises(IOError):
                     DatasetFSWriter.write_dataset(dataset_path, dataset)
 
     def test_write_documents_with_none_metadata(self, tmpdir):
         """Test writing documents with None metadata values"""
         dataset_path = str(tmpdir.mkdir("dataset"))
-        
-        documents = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": None
-            }
-        ])
-        
+
+        documents = pd.DataFrame([{"id": "1", "values": [0.1, 0.2], "metadata": None}])
+
         metadata = DatasetMetadata(
             name="test",
             created_at="2021-01-01 00:00:00.000000",
             documents=1,
             queries=0,
-            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+            dense_model=DenseModelMetadata(name="ada2", dimension=2),
         )
-        
-        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
-        
+
+        dataset = Dataset.from_pandas(
+            documents=documents, queries=None, metadata=metadata
+        )
+
         from fsspec.implementations.local import LocalFileSystem
-        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=LocalFileSystem()):
+
+        with patch(
+            "pinecone_datasets.dataset_fswriter.get_cloud_fs",
+            return_value=LocalFileSystem(),
+        ):
             # Should handle None values gracefully
             DatasetFSWriter.write_dataset(dataset_path, dataset)
-            
+
             # Verify files were created
             assert os.path.exists(os.path.join(dataset_path, "documents"))
             assert os.path.exists(os.path.join(dataset_path, "metadata.json"))
@@ -341,112 +355,117 @@ class TestFSWriterErrorPaths:
     def test_write_dataset_concurrent_access(self, tmpdir):
         """Test writing dataset with concurrent access conflicts"""
         dataset_path = str(tmpdir.mkdir("dataset"))
-        
-        documents = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"key": "value"}
-            }
-        ])
-        
+
+        documents = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": {"key": "value"}}]
+        )
+
         metadata = DatasetMetadata(
             name="test",
             created_at="2021-01-01 00:00:00.000000",
             documents=1,
             queries=0,
-            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+            dense_model=DenseModelMetadata(name="ada2", dimension=2),
         )
-        
-        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
-        
+
+        dataset = Dataset.from_pandas(
+            documents=documents, queries=None, metadata=metadata
+        )
+
         # Simulate file being locked by another process
         from fsspec.implementations.local import LocalFileSystem
-        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=LocalFileSystem()):
-            with patch('builtins.open', side_effect=BlockingIOError("Resource temporarily unavailable")):
+
+        with patch(
+            "pinecone_datasets.dataset_fswriter.get_cloud_fs",
+            return_value=LocalFileSystem(),
+        ):
+            with patch(
+                "builtins.open",
+                side_effect=BlockingIOError("Resource temporarily unavailable"),
+            ):
                 with pytest.raises(BlockingIOError):
                     DatasetFSWriter.write_dataset(dataset_path, dataset)
 
     def test_write_documents_preserves_original_metadata_on_error(self, tmpdir):
         """Test that original metadata is preserved even if write fails"""
         dataset_path = str(tmpdir.mkdir("dataset"))
-        
+
         original_metadata = {"key": "value"}
-        documents = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": original_metadata
-            }
-        ])
-        
+        documents = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": original_metadata}]
+        )
+
         metadata = DatasetMetadata(
             name="test",
             created_at="2021-01-01 00:00:00.000000",
             documents=1,
             queries=0,
-            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+            dense_model=DenseModelMetadata(name="ada2", dimension=2),
         )
-        
-        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+
+        dataset = Dataset.from_pandas(
+            documents=documents, queries=None, metadata=metadata
+        )
         original_meta_value = dataset.documents["metadata"].iloc[0]
-        
+
         # Mock to_parquet to raise error
         mock_fs = Mock()
         mock_fs.makedirs.return_value = None
-        
-        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=mock_fs):
-            with patch.object(pd.DataFrame, 'to_parquet', side_effect=IOError("Write failed")):
+
+        with patch(
+            "pinecone_datasets.dataset_fswriter.get_cloud_fs", return_value=mock_fs
+        ):
+            with patch.object(
+                pd.DataFrame, "to_parquet", side_effect=IOError("Write failed")
+            ):
                 try:
                     DatasetFSWriter.write_dataset(dataset_path, dataset)
                 except IOError:
                     pass
-        
+
         # Verify original metadata is preserved
         assert dataset.documents["metadata"].iloc[0] == original_meta_value
 
     def test_write_queries_preserves_original_filter_on_error(self, tmpdir):
         """Test that original filter is preserved even if write fails"""
         dataset_path = str(tmpdir.mkdir("dataset"))
-        
-        documents = pd.DataFrame([
-            {
-                "id": "1",
-                "values": [0.1, 0.2],
-                "metadata": {"key": "value"}
-            }
-        ])
-        
+
+        documents = pd.DataFrame(
+            [{"id": "1", "values": [0.1, 0.2], "metadata": {"key": "value"}}]
+        )
+
         original_filter = {"key": "value"}
-        queries = pd.DataFrame([
-            {
-                "vector": [0.1, 0.2],
-                "filter": original_filter,
-                "top_k": 10
-            }
-        ])
-        
+        queries = pd.DataFrame(
+            [{"vector": [0.1, 0.2], "filter": original_filter, "top_k": 10}]
+        )
+
         metadata = DatasetMetadata(
             name="test",
             created_at="2021-01-01 00:00:00.000000",
             documents=1,
             queries=1,
-            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+            dense_model=DenseModelMetadata(name="ada2", dimension=2),
         )
-        
-        dataset = Dataset.from_pandas(documents=documents, queries=queries, metadata=metadata)
+
+        dataset = Dataset.from_pandas(
+            documents=documents, queries=queries, metadata=metadata
+        )
         original_filter_value = dataset.queries["filter"].iloc[0]
-        
+
         # Mock to_parquet to raise error on queries write
         mock_fs = Mock()
         mock_fs.makedirs.return_value = None
-        
-        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=mock_fs):
-            with patch.object(pd.DataFrame, 'to_parquet', side_effect=IOError("Write failed")):
+
+        with patch(
+            "pinecone_datasets.dataset_fswriter.get_cloud_fs", return_value=mock_fs
+        ):
+            with patch.object(
+                pd.DataFrame, "to_parquet", side_effect=IOError("Write failed")
+            ):
                 try:
                     DatasetFSWriter.write_dataset(dataset_path, dataset)
                 except IOError:
                     pass
-        
+
         # Verify original filter is preserved
         assert dataset.queries["filter"].iloc[0] == original_filter_value

--- a/tests/unit/test_fswriter_errors.py
+++ b/tests/unit/test_fswriter_errors.py
@@ -1,0 +1,452 @@
+import pytest
+import json
+import os
+import pandas as pd
+from unittest.mock import Mock, patch, MagicMock
+
+from pinecone_datasets.dataset_fswriter import DatasetFSWriter
+from pinecone_datasets import Dataset, DatasetMetadata, DenseModelMetadata
+
+
+class TestFSWriterErrorPaths:
+    """Test error handling in DatasetFSWriter"""
+
+    def test_write_dataset_permission_denied(self, tmpdir):
+        """Test writing dataset with permission denied"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        
+        # Create a valid dataset
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        
+        # Mock filesystem with permission error
+        mock_fs = Mock()
+        mock_fs.makedirs.side_effect = PermissionError("Permission denied")
+        
+        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=mock_fs):
+            with pytest.raises(PermissionError):
+                DatasetFSWriter.write_dataset(dataset_path, dataset)
+
+    def test_write_dataset_disk_full(self, tmpdir):
+        """Test writing dataset when disk is full"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        
+        # Mock open to raise disk full error
+        from fsspec.implementations.local import LocalFileSystem
+        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=LocalFileSystem()):
+            with patch('builtins.open', side_effect=OSError("No space left on device")):
+                with pytest.raises(OSError, match="No space left on device"):
+                    DatasetFSWriter.write_dataset(dataset_path, dataset)
+
+    def test_convert_metadata_invalid_type(self):
+        """Test metadata conversion with invalid type"""
+        with pytest.raises(TypeError, match="metadata must be a dict"):
+            DatasetFSWriter._convert_metadata_from_dict_to_json("not a dict")
+
+    def test_convert_metadata_invalid_type_list(self):
+        """Test metadata conversion with list instead of dict"""
+        # Lists cause pd.isna() to raise ValueError, but should be caught as TypeError eventually
+        with pytest.raises((TypeError, ValueError)):
+            DatasetFSWriter._convert_metadata_from_dict_to_json([1, 2, 3])
+
+    def test_convert_metadata_invalid_type_number(self):
+        """Test metadata conversion with number instead of dict"""
+        with pytest.raises(TypeError, match="metadata must be a dict"):
+            DatasetFSWriter._convert_metadata_from_dict_to_json(123)
+
+    def test_convert_metadata_valid_dict(self):
+        """Test metadata conversion with valid dict"""
+        test_dict = {"key": "value", "number": 123}
+        result = DatasetFSWriter._convert_metadata_from_dict_to_json(test_dict)
+        assert isinstance(result, str)
+        assert json.loads(result) == test_dict
+
+    def test_convert_metadata_nan_value(self):
+        """Test metadata conversion with NaN value"""
+        result = DatasetFSWriter._convert_metadata_from_dict_to_json(float('nan'))
+        assert result is None
+
+    def test_write_documents_network_error(self, tmpdir):
+        """Test writing documents with network error"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        
+        # Mock filesystem with network error
+        mock_fs = Mock()
+        mock_fs.makedirs.return_value = None
+        
+        # Mock to_parquet to raise network error
+        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=mock_fs):
+            with patch.object(pd.DataFrame, 'to_parquet', side_effect=IOError("Network error")):
+                with pytest.raises(IOError):
+                    DatasetFSWriter.write_dataset(dataset_path, dataset)
+
+    def test_write_metadata_invalid_json_serialization(self, tmpdir):
+        """Test writing metadata that cannot be JSON serialized"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        # Create metadata with non-serializable object
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        
+        # Mock model_dump to return non-serializable data
+        with patch.object(DatasetMetadata, 'model_dump', return_value={"func": lambda x: x}):
+            from fsspec.implementations.local import LocalFileSystem
+            with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=LocalFileSystem()):
+                with pytest.raises(TypeError):
+                    DatasetFSWriter.write_dataset(dataset_path, dataset)
+
+    def test_write_dataset_invalid_path(self):
+        """Test writing dataset to invalid path"""
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        
+        # Try to write to invalid path
+        with pytest.raises(Exception):  # Could be various errors depending on OS
+            DatasetFSWriter.write_dataset("/invalid/\x00/path", dataset)
+
+    def test_write_documents_readonly_filesystem(self, tmpdir):
+        """Test writing documents to read-only filesystem"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        
+        # Mock filesystem as read-only
+        mock_fs = Mock()
+        mock_fs.makedirs.side_effect = OSError("Read-only file system")
+        
+        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=mock_fs):
+            with pytest.raises(OSError, match="Read-only file system"):
+                DatasetFSWriter.write_dataset(dataset_path, dataset)
+
+    def test_write_queries_with_invalid_filter_type(self, tmpdir):
+        """Test writing queries with invalid filter type"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        # Queries with invalid filter type (should be dict)
+        queries = pd.DataFrame([
+            {
+                "vector": [0.1, 0.2],
+                "filter": "invalid_filter_type",  # Should be dict
+                "top_k": 10
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=1,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=queries, metadata=metadata)
+        
+        from fsspec.implementations.local import LocalFileSystem
+        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=LocalFileSystem()):
+            with pytest.raises(TypeError):
+                DatasetFSWriter.write_dataset(dataset_path, dataset)
+
+    def test_write_empty_queries_warning(self, tmpdir):
+        """Test that writing empty queries produces a warning"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        
+        from fsspec.implementations.local import LocalFileSystem
+        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=LocalFileSystem()):
+            with pytest.warns(UserWarning, match="Queries are empty"):
+                DatasetFSWriter.write_dataset(dataset_path, dataset)
+
+    def test_write_metadata_file_open_error(self, tmpdir):
+        """Test writing metadata when file cannot be opened"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        
+        # Mock open to fail when writing metadata
+        from fsspec.implementations.local import LocalFileSystem
+        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=LocalFileSystem()):
+            with patch('builtins.open', side_effect=IOError("Cannot open file")):
+                with pytest.raises(IOError):
+                    DatasetFSWriter.write_dataset(dataset_path, dataset)
+
+    def test_write_documents_with_none_metadata(self, tmpdir):
+        """Test writing documents with None metadata values"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": None
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        
+        from fsspec.implementations.local import LocalFileSystem
+        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=LocalFileSystem()):
+            # Should handle None values gracefully
+            DatasetFSWriter.write_dataset(dataset_path, dataset)
+            
+            # Verify files were created
+            assert os.path.exists(os.path.join(dataset_path, "documents"))
+            assert os.path.exists(os.path.join(dataset_path, "metadata.json"))
+
+    def test_write_dataset_concurrent_access(self, tmpdir):
+        """Test writing dataset with concurrent access conflicts"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        
+        # Simulate file being locked by another process
+        from fsspec.implementations.local import LocalFileSystem
+        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=LocalFileSystem()):
+            with patch('builtins.open', side_effect=BlockingIOError("Resource temporarily unavailable")):
+                with pytest.raises(BlockingIOError):
+                    DatasetFSWriter.write_dataset(dataset_path, dataset)
+
+    def test_write_documents_preserves_original_metadata_on_error(self, tmpdir):
+        """Test that original metadata is preserved even if write fails"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        
+        original_metadata = {"key": "value"}
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": original_metadata
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=0,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=None, metadata=metadata)
+        original_meta_value = dataset.documents["metadata"].iloc[0]
+        
+        # Mock to_parquet to raise error
+        mock_fs = Mock()
+        mock_fs.makedirs.return_value = None
+        
+        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=mock_fs):
+            with patch.object(pd.DataFrame, 'to_parquet', side_effect=IOError("Write failed")):
+                try:
+                    DatasetFSWriter.write_dataset(dataset_path, dataset)
+                except IOError:
+                    pass
+        
+        # Verify original metadata is preserved
+        assert dataset.documents["metadata"].iloc[0] == original_meta_value
+
+    def test_write_queries_preserves_original_filter_on_error(self, tmpdir):
+        """Test that original filter is preserved even if write fails"""
+        dataset_path = str(tmpdir.mkdir("dataset"))
+        
+        documents = pd.DataFrame([
+            {
+                "id": "1",
+                "values": [0.1, 0.2],
+                "metadata": {"key": "value"}
+            }
+        ])
+        
+        original_filter = {"key": "value"}
+        queries = pd.DataFrame([
+            {
+                "vector": [0.1, 0.2],
+                "filter": original_filter,
+                "top_k": 10
+            }
+        ])
+        
+        metadata = DatasetMetadata(
+            name="test",
+            created_at="2021-01-01 00:00:00.000000",
+            documents=1,
+            queries=1,
+            dense_model=DenseModelMetadata(name="ada2", dimension=2)
+        )
+        
+        dataset = Dataset.from_pandas(documents=documents, queries=queries, metadata=metadata)
+        original_filter_value = dataset.queries["filter"].iloc[0]
+        
+        # Mock to_parquet to raise error on queries write
+        mock_fs = Mock()
+        mock_fs.makedirs.return_value = None
+        
+        with patch('pinecone_datasets.dataset_fswriter.get_cloud_fs', return_value=mock_fs):
+            with patch.object(pd.DataFrame, 'to_parquet', side_effect=IOError("Write failed")):
+                try:
+                    DatasetFSWriter.write_dataset(dataset_path, dataset)
+                except IOError:
+                    pass
+        
+        # Verify original filter is preserved
+        assert dataset.queries["filter"].iloc[0] == original_filter_value

--- a/tests/unit/test_fswriter_errors.py
+++ b/tests/unit/test_fswriter_errors.py
@@ -1,9 +1,9 @@
 import json
 import os
+from unittest.mock import Mock, patch
 
 import pandas as pd
 import pytest
-from unittest.mock import Mock, patch
 
 from pinecone_datasets import Dataset, DatasetMetadata, DenseModelMetadata
 from pinecone_datasets.dataset_fswriter import DatasetFSWriter

--- a/tests/unit/test_fswriter_errors.py
+++ b/tests/unit/test_fswriter_errors.py
@@ -1,11 +1,12 @@
-import pytest
 import json
 import os
-import pandas as pd
-from unittest.mock import Mock, patch, MagicMock
 
-from pinecone_datasets.dataset_fswriter import DatasetFSWriter
+import pandas as pd
+import pytest
+from unittest.mock import Mock, patch
+
 from pinecone_datasets import Dataset, DatasetMetadata, DenseModelMetadata
+from pinecone_datasets.dataset_fswriter import DatasetFSWriter
 
 
 class TestFSWriterErrorPaths:
@@ -130,9 +131,9 @@ class TestFSWriterErrorPaths:
             "pinecone_datasets.dataset_fswriter.get_cloud_fs", return_value=mock_fs
         ):
             with patch.object(
-                pd.DataFrame, "to_parquet", side_effect=IOError("Network error")
+                pd.DataFrame, "to_parquet", side_effect=OSError("Network error")
             ):
-                with pytest.raises(IOError):
+                with pytest.raises(OSError):
                     DatasetFSWriter.write_dataset(dataset_path, dataset)
 
     def test_write_metadata_invalid_json_serialization(self, tmpdir):
@@ -317,8 +318,8 @@ class TestFSWriterErrorPaths:
             "pinecone_datasets.dataset_fswriter.get_cloud_fs",
             return_value=LocalFileSystem(),
         ):
-            with patch("builtins.open", side_effect=IOError("Cannot open file")):
-                with pytest.raises(IOError):
+            with patch("builtins.open", side_effect=OSError("Cannot open file")):
+                with pytest.raises(OSError):
                     DatasetFSWriter.write_dataset(dataset_path, dataset)
 
     def test_write_documents_with_none_metadata(self, tmpdir):
@@ -416,11 +417,11 @@ class TestFSWriterErrorPaths:
             "pinecone_datasets.dataset_fswriter.get_cloud_fs", return_value=mock_fs
         ):
             with patch.object(
-                pd.DataFrame, "to_parquet", side_effect=IOError("Write failed")
+                pd.DataFrame, "to_parquet", side_effect=OSError("Write failed")
             ):
                 try:
                     DatasetFSWriter.write_dataset(dataset_path, dataset)
-                except IOError:
+                except OSError:
                     pass
 
         # Verify original metadata is preserved
@@ -460,11 +461,11 @@ class TestFSWriterErrorPaths:
             "pinecone_datasets.dataset_fswriter.get_cloud_fs", return_value=mock_fs
         ):
             with patch.object(
-                pd.DataFrame, "to_parquet", side_effect=IOError("Write failed")
+                pd.DataFrame, "to_parquet", side_effect=OSError("Write failed")
             ):
                 try:
                     DatasetFSWriter.write_dataset(dataset_path, dataset)
-                except IOError:
+                except OSError:
                     pass
 
         # Verify original filter is preserved


### PR DESCRIPTION
Add comprehensive error path test coverage to improve confidence in error handling across critical components.

This PR introduces 122 new unit and integration tests covering various error scenarios for `FSReader`, `FSWriter`, `Catalog`, and `fs` modules, addressing network failures, corrupted data, missing metadata, invalid paths, concurrent access, and edge cases.

---
Linear Issue: [SDK-290](https://linear.app/pinecone-io/issue/SDK-290/add-comprehensive-error-path-test-coverage)

<a href="https://cursor.com/background-agent?bcId=bc-c1012022-a36d-4517-b538-775c3944afb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c1012022-a36d-4517-b538-775c3944afb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production code is unchanged, but the new large/concurrent integration tests may increase CI runtime and introduce flakiness or resource pressure in some environments.
> 
> **Overview**
> **Adds broad error-path test coverage** for dataset IO and catalog operations, exercising corrupted/empty parquet inputs, invalid or missing metadata, schema mismatches, and permission/network failures.
> 
> Also introduces **integration stress scenarios** (concurrent reads/writes, partial writes, large dataset iteration, unicode metadata, and mixed-schema parquet sets) to validate behavior under concurrency and edge conditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3782c161d97c3d3565a2b2ed6061d508636d215. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->