### PR TITLE
fix(ui): improve progress bar message readability

### DIFF
--- a/pinecone_datasets/dataset_fsreader.py
+++ b/pinecone_datasets/dataset_fsreader.py
@@ -96,7 +96,7 @@ class DatasetFSReader:
 
             # First, collect all the dataframes
             dfs = []
-            for path in tqdm(read_path, desc=f"Loading {data_type} parquet files"):
+            for path in tqdm(read_path, desc=f"Loading {data_type}"):
                 if use_cache_for_dataset and protocol:
                     # Reconstruct full URL if path doesn't have protocol
                     if not path.startswith(protocol):


### PR DESCRIPTION
## Problem

When loading datasets, the progress bar displays grammatically awkward messages like:
- "Loading documents parquet files"  
- "Loading queries parquet files"

The issue is using plural nouns ("documents", "queries") as adjective modifiers before "parquet files", which reads unnaturally.

## Solution

Simplified the progress bar description to just "Loading documents" and "Loading queries". Since all dataset files are stored exclusively as parquet format (this is enforced in the code), mentioning "parquet files" is redundant implementation detail that doesn't help users.

## Changes

- Updated `dataset_fsreader.py` line 99: changed tqdm description from `f"Loading {data_type} parquet files"` to `f"Loading {data_type}"`
- Results in cleaner, more professional progress messages

## Testing

- ✅ All 190 tests pass (3 skipped as expected)
- ✅ No breaking changes
- ✅ Backward compatible - only affects UI text

## Example

**Before:**
```
Loading documents parquet files: 100%|████████| 2/2 [00:01<00:00,  1.23it/s]
```

**After:**
```
Loading documents: 100%|████████| 2/2 [00:01<00:00,  1.23it/s]
```

The simpler message is easier to read and sounds more natural while conveying the same information to users.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the `tqdm` progress bar description string during dataset parquet loading, with no impact on IO, parsing, or schema validation logic.
> 
> **Overview**
> Improves dataset loading UX by simplifying the `tqdm` progress message in `DatasetFSReader._safe_read_from_path` from “Loading {data_type} parquet files” to just “Loading {data_type}”, removing redundant/awkward wording while keeping behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2131394b5ac345f17f3e005484432abf4a44b1d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->