### PR TITLE
feat(ui): add download progress feedback with tqdm

### DIFF
--- a/pinecone_datasets/cache.py
+++ b/pinecone_datasets/cache.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 from .fs import CloudOrLocalFS
+from .tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -192,7 +193,7 @@ class CacheManager:
         etag: Optional[str] = None,
     ) -> None:
         """
-        Download a file from remote storage with resume support.
+        Download a file from remote storage with resume support and progress feedback.
 
         Args:
             remote_url: Remote file URL
@@ -210,31 +211,44 @@ class CacheManager:
             else output_path
         )
         metadata_path = self._get_metadata_path(base_path)
+        
+        # Get filename for progress bar description
+        filename = os.path.basename(remote_url)
 
         logger.debug(
             f"Downloading {remote_url} to {output_path} (starting at byte {start_byte})"
         )
 
-        with fs.open(remote_url, "rb") as remote:
-            if start_byte > 0:
-                remote.seek(start_byte)
+        # Create progress bar for download
+        with tqdm(
+            total=file_size,
+            initial=start_byte,
+            unit="B",
+            unit_scale=True,
+            unit_divisor=1024,
+            desc=f"Downloading {filename}",
+        ) as pbar:
+            with fs.open(remote_url, "rb") as remote:
+                if start_byte > 0:
+                    remote.seek(start_byte)
 
-            with open(output_path, mode) as local:
-                bytes_written = start_byte
-                chunk_size = 1024 * 1024  # 1MB chunks
+                with open(output_path, mode) as local:
+                    bytes_written = start_byte
+                    chunk_size = 1024 * 1024  # 1MB chunks
 
-                while True:
-                    chunk = remote.read(chunk_size)
-                    if not chunk:
-                        break
-                    local.write(chunk)
-                    bytes_written += len(chunk)
+                    while True:
+                        chunk = remote.read(chunk_size)
+                        if not chunk:
+                            break
+                        local.write(chunk)
+                        bytes_written += len(chunk)
+                        pbar.update(len(chunk))
 
-                    # Update metadata every 10MB for crash recovery
-                    if bytes_written % (10 * 1024 * 1024) < chunk_size:
-                        self._write_metadata(
-                            metadata_path, remote_url, file_size, bytes_written, etag
-                        )
+                        # Update metadata every 10MB for crash recovery
+                        if bytes_written % (10 * 1024 * 1024) < chunk_size:
+                            self._write_metadata(
+                                metadata_path, remote_url, file_size, bytes_written, etag
+                            )
 
     def get_cached_path(self, remote_url: str, fs: CloudOrLocalFS) -> str:
         """

--- a/pinecone_datasets/cache.py
+++ b/pinecone_datasets/cache.py
@@ -211,7 +211,7 @@ class CacheManager:
             else output_path
         )
         metadata_path = self._get_metadata_path(base_path)
-        
+
         # Get filename for progress bar description
         filename = os.path.basename(remote_url)
 
@@ -247,7 +247,11 @@ class CacheManager:
                         # Update metadata every 10MB for crash recovery
                         if bytes_written % (10 * 1024 * 1024) < chunk_size:
                             self._write_metadata(
-                                metadata_path, remote_url, file_size, bytes_written, etag
+                                metadata_path,
+                                remote_url,
+                                file_size,
+                                bytes_written,
+                                etag,
                             )
 
     def get_cached_path(self, remote_url: str, fs: CloudOrLocalFS) -> str:


### PR DESCRIPTION
## Problem

When loading datasets from cloud storage, users see no feedback during downloads. For large datasets, this creates a poor experience as users don't know if the download is progressing, stalled, or how long it will take.

## Solution

Added byte-level progress bars to dataset downloads using tqdm. The progress bar shows:
- Total file size and bytes downloaded
- Download speed (MB/s)
- Estimated time remaining (ETA)
- Progress percentage
- Support for resumed downloads (shows already-downloaded bytes)

## Changes

**`pinecone_datasets/cache.py`:**
- Import tqdm
- Wrap `_download_file` method with tqdm progress bar
- Display filename, file size, and download progress
- Update progress bar on each chunk downloaded

## Testing

- ✅ All 190 tests pass (3 skipped)
- ✅ No linter errors
- ✅ Cache tests validate download functionality
- ✅ Integration tests verify cloud storage operations

## Example Output

```
Downloading part-0.parquet: 100%|████████| 1.23M/1.23M [00:02<00:00, 512kB/s]
```

When resuming an interrupted download:

```
Downloading part-0.parquet:  45%|████     | 512k/1.23M [00:01<00:01, 498kB/s]
```

## Related

- Closes SDK-321
- Part of SDK-319 (Download Progress, Resumable Downloads, and Dataset Rebuilding)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to wrapping file downloads with a `tqdm` progress bar; primary risk is minor output/TTY compatibility or overhead during downloads.
> 
> **Overview**
> Adds byte-level download progress feedback to cached dataset downloads by wrapping `CacheManager._download_file` with a `tqdm` progress bar.
> 
> The progress bar is initialized with the remote file size and resume offset (`initial=start_byte`), updates on each chunk written, and displays the filename in the description while keeping existing resumable/metadata behavior intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f040bab6fce41857d229edd9604f46df8541790b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->