### PR TITLE
ci: add least-privilege workflow permissions (CodeQL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
       branches:
         - main
 
+permissions:
+  contents: read
+
 jobs:
   linting:
     name: Run lint and type checking


### PR DESCRIPTION
## Summary

- Adds a top-level `permissions: contents: read` block to `.github/workflows/ci.yml`
- Both jobs (`linting` and `run-tests`) are read-only CI; no write permissions are needed
- Resolves CodeQL `actions/missing-workflow-permissions` alerts #6 and #7

Closes PIN-24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line workflow hardening with no application or runtime changes; verify `upload-artifact` still succeeds under the narrowed token if CI fails post-merge.
> 
> **Overview**
> Adds an explicit workflow-level **`permissions: contents: read`** block to **`ci.yml`**, replacing the implicit broad default for the `GITHUB_TOKEN` on push/PR to `main`.
> 
> This scopes both **`linting`** and **`run-tests`** to read-only repository access, matching jobs that only checkout code, run checks/tests, and use secrets—addressing CodeQL **`actions/missing-workflow-permissions`** (alerts #6 and #7).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfb83432d64607a819950cff8e6d94cd3a2b5e12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->