### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in this repo.
+* @pinecone-io/sdk


### PR DESCRIPTION
Adds a CODEOWNERS file so review requests (including the maintenance fleet's fix-PRs) route to the owning team(s): `* @pinecone-io/sdk`.

Backfill for a repo already in the groundskeeper maintenance fleet's managed set (`.github/managed-repos.json`). A human reviews and merges — this is opened, not merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-style GitHub config only; no code, build, or deployment impact.
> 
> **Overview**
> Adds a **`.github/CODEOWNERS`** file so GitHub automatically requests reviews from **`@pinecone-io/sdk`** for changes across the repo (`*` default rule).
> 
> This is repo governance only—no application or runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5abee664568cdbad94c7568c5b10c3f0dfb72b72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->