### PR TITLE
ci: add pip-audit gate, drop EOL Python 3.10, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: "/"
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.12']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -41,6 +41,18 @@ jobs:
     - name: Run mypy check
       run: uv run mypy .
 
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+    - name: Audit locked dependencies
+      run: |
+        uv export --format requirements-txt --all-extras --no-emit-project > requirements-audit.txt
+        uvx pip-audit -r requirements-audit.txt
+
   run-tests:
     name: Run tests
     needs: linting
@@ -48,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', 3.11, 3.12, 3.13]
+        python-version: [3.11, 3.12, 3.13]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## What

Brings `pinecone-datasets` to the standard CI bar. Existing CI already runs ruff format check, ruff lint, mypy, and pytest with coverage across a Python matrix (uv-based, least-privilege). This PR:

1. **Adds a dependency-audit job** — runs `pip-audit` against the exported `uv.lock`, failing CI on known advisories.
2. **Drops near-EOL Python 3.10** — the lint job moves 3.10 → 3.12, and the test matrix becomes `[3.11, 3.12, 3.13]` (per the goal of not testing EOL runtimes).
3. **Adds `.github/dependabot.yml`** — weekly pip (uv) + github-actions updates (grouped).

## Verification (local)

- `uv export --format requirements-txt --all-extras | pip-audit -r` → **No known vulnerabilities found** ✅.

## Follow-up (your call)

`requires-python` is still `>=3.10,<3.14`. If 3.10 is being formally dropped, bump it to `>=3.11` in a separate packaging PR — I left that out since it changes the published support policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and automation-only changes; no runtime application logic, though dropping 3.10 from the matrix changes which Python versions are validated before release.
> 
> **Overview**
> Raises the CI bar with **automated dependency hygiene** and **narrower Python coverage**.
> 
> A new **Dependency audit** job exports locked requirements from `uv.lock` and runs **`pip-audit`**, so CI fails on known advisories in resolved dependencies. **Lint/type-check** now runs on **Python 3.12** (was 3.10), and the **test matrix** is **3.11–3.13** only—**3.10 is no longer exercised** in CI (packaging `requires-python` may still allow 3.10 until a follow-up).
> 
> **Dependabot** is added via `.github/dependabot.yml` for weekly **uv** updates (minor/patch grouped, cap 10 open PRs) and **GitHub Actions** updates (cap 5).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61996a3316f97ba9231355f9c0583df597695103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->